### PR TITLE
Release v3.4

### DIFF
--- a/app/Console/Commands/SendSettlementReminders.php
+++ b/app/Console/Commands/SendSettlementReminders.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Mail\OrderInvoice;
+use App\Models\Order;
+use App\Support\OrderPresenter;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+class SendSettlementReminders extends Command
+{
+    protected $signature = 'orders:settlement-reminders
+        {--date= : Anggap hari ini sebagai tanggal ini (YYYY-MM-DD), untuk pengujian}
+        {--force : Kirim ulang walau tahap pengingat sudah pernah terkirim}';
+
+    protected $description = 'Kirim email pengingat pelunasan DP pada H-7, H-5, H-3, dan Hari-H sebelum tenggat.';
+
+    public function handle(): int
+    {
+        $deadline = Carbon::parse(config('settlement.deadline'))->startOfDay();
+        $today = $this->option('date')
+            ? Carbon::parse($this->option('date'))->startOfDay()
+            : Carbon::now()->startOfDay();
+
+        $offsets = config('settlement.reminder_offsets', [7, 5, 3, 0]);
+
+        // Tentukan tahap pengingat yang jatuh tepat hari ini.
+        $offset = null;
+        foreach ($offsets as $o) {
+            if ($deadline->copy()->subDays($o)->isSameDay($today)) {
+                $offset = $o;
+                break;
+            }
+        }
+
+        if ($offset === null) {
+            $this->info('Tidak ada jadwal pengingat pelunasan untuk hari ini ('.$today->toDateString().').');
+
+            return self::SUCCESS;
+        }
+
+        $stageKey = 'h-'.$offset;
+        $stageLabel = $offset === 0 ? 'Hari H' : 'H-'.$offset;
+        $deadlineLabel = $deadline->copy()->locale('id')->translatedFormat('d F Y');
+
+        $this->info("Pengingat pelunasan tahap {$stageLabel} (tenggat {$deadlineLabel}).");
+
+        // Pesanan DP yang DP-nya sudah diverifikasi tetapi belum lunas & masih ada sisa.
+        $orders = Order::query()
+            ->where('payment_type', 'dp')
+            ->where('status', 'verified')
+            ->whereNull('dp_settlement_verified_at')
+            ->whereColumn('amount_due', '<', 'subtotal')
+            ->get();
+
+        $sent = 0;
+        $skipped = 0;
+
+        foreach ($orders as $order) {
+            $reminders = $order->dp_settlement_reminders ?? [];
+
+            if (! $this->option('force') && in_array($stageKey, $reminders, true)) {
+                $skipped++;
+
+                continue;
+            }
+
+            $data = OrderPresenter::mailData($order);
+            $data['reminder'] = [
+                'stage' => $stageLabel,
+                'deadline_label' => $deadlineLabel,
+                'is_due' => $offset === 0,
+            ];
+
+            try {
+                Mail::to($order->customer_email)->send(new OrderInvoice($data, 'reminder'));
+
+                if (! in_array($stageKey, $reminders, true)) {
+                    $reminders[] = $stageKey;
+                }
+                $order->update(['dp_settlement_reminders' => $reminders]);
+                $sent++;
+                $this->line("  ✓ {$order->order_id} → {$order->customer_email}");
+            } catch (\Throwable $e) {
+                Log::error('Failed to send settlement reminder', [
+                    'order_id' => $order->order_id,
+                    'stage' => $stageKey,
+                    'error' => $e->getMessage(),
+                ]);
+                $this->error("  ✗ {$order->order_id}: {$e->getMessage()}");
+            }
+        }
+
+        $this->info("Selesai. Terkirim: {$sent}, dilewati (sudah pernah): {$skipped}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -2,10 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Mail\OrderInvoice;
 use App\Models\Order;
+use App\Support\OrderPresenter;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
@@ -320,17 +324,32 @@ class AdminController extends Controller
             ], 422);
         }
 
-        if ($next === 'completed' && $order->payment_type === 'dp' && empty($order->dp_settlement_proof)) {
+        if ($next === 'completed' && $order->payment_type === 'dp' && empty($order->dp_settlement_verified_at)) {
             return response()->json([
                 'ok' => false,
-                'message' => 'Upload bukti pelunasan DP terlebih dahulu sebelum menandai selesai.',
+                'message' => 'Verifikasi pelunasan DP terlebih dahulu sebelum menandai selesai.',
             ], 422);
         }
+
+        $wasVerified = $order->status === 'verified';
 
         $order->status = $next;
         $order->verified_at = $next === 'verified' ? ($order->verified_at ?? now()) : ($next === 'pending' ? null : $order->verified_at);
         $order->completed_at = $next === 'completed' ? now() : null;
         $order->save();
+
+        // Pembayaran baru diverifikasi admin → kirim email invoice/pembayaran diterima.
+        if ($next === 'verified' && ! $wasVerified) {
+            $hasRemaining = (int) $order->subtotal - (int) $order->amount_due > 0;
+
+            if ($order->payment_type === 'dp' && empty($order->dp_settlement_verified_at) && $hasRemaining) {
+                // DP diterima → ajakan pelunasan.
+                $this->sendOrderMail($order, 'dp-verified');
+            } else {
+                // Pembayaran penuh (atau DP tanpa sisa) → invoice pembayaran diterima.
+                $this->sendOrderMail($order, 'invoice');
+            }
+        }
 
         return response()->json([
             'ok' => true,
@@ -406,9 +425,61 @@ class AdminController extends Controller
         }
 
         $path = $validated['proof']->store('proofs/settlements', 'public');
-        $order->update(['dp_settlement_proof' => $path]);
+        $alreadyVerified = (bool) $order->dp_settlement_verified_at;
+        $order->update([
+            'dp_settlement_proof' => $path,
+            'dp_settlement_uploaded_at' => $order->dp_settlement_uploaded_at ?? now(),
+            'dp_settlement_verified_at' => now(),
+        ]);
 
-        return response()->json(['ok' => true, 'message' => 'Bukti pelunasan tersimpan.']);
+        if (! $alreadyVerified) {
+            $this->sendOrderMail($order, 'settlement-verified');
+        }
+
+        return response()->json([
+            'ok' => true,
+            'message' => 'Bukti pelunasan tersimpan & terverifikasi.',
+            'stats' => $this->orderStats(),
+        ]);
+    }
+
+    public function verifySettlement(Request $request, Order $order)
+    {
+        if ($order->payment_type !== 'dp') {
+            return response()->json(['ok' => false, 'message' => 'Pesanan bukan tipe DP.'], 422);
+        }
+
+        if (empty($order->dp_settlement_proof)) {
+            return response()->json(['ok' => false, 'message' => 'Belum ada bukti pelunasan untuk diverifikasi.'], 422);
+        }
+
+        if ($order->dp_settlement_verified_at) {
+            return response()->json(['ok' => false, 'message' => 'Pelunasan sudah diverifikasi.'], 422);
+        }
+
+        $order->update(['dp_settlement_verified_at' => now()]);
+
+        $this->sendOrderMail($order, 'settlement-verified');
+
+        return response()->json([
+            'ok' => true,
+            'message' => 'Pelunasan DP terverifikasi.',
+            'stats' => $this->orderStats(),
+        ]);
+    }
+
+    private function sendOrderMail(Order $order, string $mode): void
+    {
+        try {
+            Mail::to($order->customer_email)
+                ->send(new OrderInvoice(OrderPresenter::mailData($order), $mode));
+        } catch (\Throwable $e) {
+            Log::error('Failed to send order mail', [
+                'order_id' => $order->order_id,
+                'mode' => $mode,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     public function showOrder(Order $order)
@@ -701,19 +772,7 @@ class AdminController extends Controller
             .($order->payment_type === 'dp' ? '<div class="text-[10px] text-white/80">dari total '.$rupiah($order->subtotal).'</div>' : '')
             .'</div>'
             .'</div>'
-            .($order->payment_type === 'dp'
-                ? '<div class="mt-3 flex items-center justify-between rounded-xl border-2 border-dashed border-amber-300 bg-amber-50 px-4 py-3">'
-                    .'<div class="inline-flex items-center gap-2 text-amber-800">'
-                    .'<i class="ri-alarm-warning-line text-base"></i>'
-                    .'<span class="text-[12px] font-semibold">'.($order->dp_settlement_proof ? 'Pelunasan diterima' : 'Sisa pelunasan DP').'</span>'
-                    .'</div>'
-                    .'<span class="text-[14px] font-black '.($order->dp_settlement_proof ? 'text-emerald-700' : 'text-amber-700').'">'
-                    .($order->dp_settlement_proof
-                        ? '<i class="ri-checkbox-circle-fill"></i> Lunas'
-                        : $rupiah(max(0, $order->subtotal - $order->amount_due)))
-                    .'</span>'
-                    .'</div>'
-                : '')
+            .($order->payment_type === 'dp' ? $this->renderSettlementBlock($order, $rupiah) : '')
             .'<div class="mt-3 flex flex-wrap items-center gap-2">'.$proofHtml.'</div>'
             .'</div>'
 
@@ -751,6 +810,44 @@ class AdminController extends Controller
             .'</div>';
     }
 
+    private function renderSettlementBlock(Order $order, callable $rupiah): string
+    {
+        $remaining = max(0, (int) $order->subtotal - (int) $order->amount_due);
+        $verified = (bool) $order->dp_settlement_verified_at;
+        $hasProof = (bool) $order->dp_settlement_proof;
+
+        if ($verified) {
+            $label = 'Pelunasan terverifikasi';
+            $valueHtml = '<span class="text-[14px] font-black text-emerald-700"><i class="ri-checkbox-circle-fill"></i> Lunas</span>';
+            $box = 'border-emerald-300 bg-emerald-50';
+            $icon = '<i class="ri-checkbox-circle-line text-base text-emerald-600"></i>';
+            $textColor = 'text-emerald-800';
+            $action = '';
+        } elseif ($hasProof) {
+            $label = 'Menunggu verifikasi pelunasan';
+            $valueHtml = '<span class="text-[14px] font-black text-amber-700">'.$rupiah($remaining).'</span>';
+            $box = 'border-amber-300 bg-amber-50';
+            $icon = '<i class="ri-time-line text-base text-amber-600"></i>';
+            $textColor = 'text-amber-800';
+            $action = '<button type="button" data-action="settlement-verify" data-order="'.e($order->order_id).'" class="mt-2.5 inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-emerald-600 px-3 py-2 text-[12px] font-bold text-white shadow-sm transition active:scale-95 hover:bg-emerald-700"><i class="ri-shield-check-line"></i> Verifikasi Pelunasan</button>';
+        } else {
+            $label = 'Menunggu pelunasan pembeli';
+            $valueHtml = '<span class="text-[14px] font-black text-amber-700">'.$rupiah($remaining).'</span>';
+            $box = 'border-amber-300 bg-amber-50';
+            $icon = '<i class="ri-alarm-warning-line text-base text-amber-600"></i>';
+            $textColor = 'text-amber-800';
+            $action = '';
+        }
+
+        return '<div class="mt-3 rounded-xl border-2 border-dashed '.$box.' px-4 py-3">'
+            .'<div class="flex items-center justify-between">'
+            .'<div class="inline-flex items-center gap-2 '.$textColor.'">'.$icon
+            .'<span class="text-[12px] font-semibold">'.$label.'</span>'
+            .'</div>'.$valueHtml
+            .'</div>'.$action
+            .'</div>';
+    }
+
     private function renderActions(Order $order): string
     {
         $orderId = e($order->order_id);
@@ -762,6 +859,13 @@ class AdminController extends Controller
         if ($order->status === 'pending') {
             $items .= '<button type="button" role="menuitem" data-action="status" data-status="verified" data-order="'.$orderId.'" class="dropdown-item dropdown-item--success">'
                 .'<i class="ri-shield-check-line"></i><span>Pembayaran Diterima</span>'
+                .'</button>';
+        }
+
+        if ($order->payment_type === 'dp' && $order->dp_settlement_proof && ! $order->dp_settlement_verified_at
+            && $order->status !== 'cancelled') {
+            $items .= '<button type="button" role="menuitem" data-action="settlement-verify" data-order="'.$orderId.'" class="dropdown-item dropdown-item--success">'
+                .'<i class="ri-shield-check-line"></i><span>Verifikasi Pelunasan</span>'
                 .'</button>';
         }
 

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -172,6 +172,118 @@ class CheckoutController extends Controller
         return redirect()->route('checkout.payment', ['orderId' => strtolower($order->order_id)]);
     }
 
+    /**
+     * Tentukan tahap pelunasan DP sebuah pesanan.
+     *
+     * not_dp    : bukan pesanan DP, tidak ada pelunasan.
+     * cancelled : pesanan dibatalkan.
+     * done      : sudah lunas (pelunasan terverifikasi / pesanan selesai / tidak ada sisa).
+     * review    : bukti pelunasan sudah diunggah, menunggu verifikasi admin.
+     * locked    : DP belum diverifikasi admin, pelunasan belum bisa dibayar.
+     * open      : siap dilunasi (DP terverifikasi, masih ada sisa).
+     */
+    private function settlementState(Order $order): string
+    {
+        if ($order->payment_type !== 'dp') {
+            return 'not_dp';
+        }
+        if ($order->status === 'cancelled') {
+            return 'cancelled';
+        }
+        if ($order->dp_settlement_verified_at || $order->status === 'completed'
+            || (int) $order->subtotal - (int) $order->amount_due <= 0) {
+            return 'done';
+        }
+        if ($order->dp_settlement_proof) {
+            return 'review';
+        }
+        if ($order->status !== 'verified') {
+            return 'locked';
+        }
+
+        return 'open';
+    }
+
+    public function settlement(string $orderId)
+    {
+        $order = Order::where('order_id', $orderId)->first();
+        if (! $order) {
+            return redirect()->route('checkout')
+                ->with('status', 'Pesanan tidak ditemukan.');
+        }
+
+        if ($order->payment_type !== 'dp') {
+            return redirect()->route('checkout.payment', ['orderId' => strtolower($order->order_id)]);
+        }
+
+        if ($order->status === 'cancelled') {
+            return $this->redirectClosedOrder($order);
+        }
+
+        return view('pages.checkout.settlement', [
+            'title' => 'Pelunasan',
+            'order' => $this->buildOrderView($order),
+        ]);
+    }
+
+    public function uploadSettlement(Request $request, string $orderId)
+    {
+        $order = Order::where('order_id', $orderId)->first();
+        if (! $order) {
+            return back()->with('proof_status', 'error')
+                ->with('proof_message', 'Pesanan tidak ditemukan.');
+        }
+
+        $state = $this->settlementState($order);
+
+        if (! in_array($state, ['open', 'review'], true)) {
+            $messages = [
+                'not_dp' => 'Pesanan ini bukan tipe DP.',
+                'cancelled' => 'Pesanan ini telah dibatalkan.',
+                'done' => 'Pesanan ini sudah lunas.',
+                'locked' => 'DP kamu masih menunggu verifikasi admin. Pelunasan dapat dilakukan setelah DP diterima.',
+            ];
+
+            return redirect()->route('checkout.settlement', ['orderId' => strtolower($order->order_id)])
+                ->with('proof_status', 'error')
+                ->with('proof_message', $messages[$state] ?? 'Pelunasan tidak dapat diproses.');
+        }
+
+        $validated = $request->validate([
+            'proof' => ['required', 'file', 'mimes:jpg,jpeg,png,webp,pdf', 'max:5120'],
+        ], [
+            'proof.required' => 'File bukti pelunasan wajib dipilih.',
+            'proof.mimes' => 'Format file harus jpg, jpeg, png, webp, atau pdf.',
+            'proof.max' => 'Ukuran file maksimal 5MB.',
+        ]);
+
+        if ($order->dp_settlement_proof) {
+            Storage::disk('public')->delete($order->dp_settlement_proof);
+        }
+
+        $path = $validated['proof']->store('proofs/settlements', 'public');
+
+        $order->update([
+            'dp_settlement_proof' => $path,
+            'dp_settlement_uploaded_at' => now(),
+            'dp_settlement_verified_at' => null,
+        ]);
+
+        try {
+            Mail::to($order->customer_email)
+                ->send(new OrderInvoice($this->buildOrderView($order), 'settlement-received'));
+        } catch (\Throwable $e) {
+            Log::error('Failed to send settlement email', [
+                'order_id' => $order->order_id,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return redirect()->route('checkout.settlement', ['orderId' => strtolower($order->order_id)])
+            ->with('proof_status', 'success')
+            ->with('proof_message', 'Bukti pelunasan berhasil diunggah. Admin akan memverifikasi pembayaranmu.');
+    }
+
     private function buildOrderView(Order $order): array
     {
         return [
@@ -202,10 +314,20 @@ class CheckoutController extends Controller
             'items' => $order->item ?? [],
             'subtotal' => $order->subtotal,
             'amount_due' => $order->amount_due,
+            'remaining' => max(0, (int) $order->subtotal - (int) $order->amount_due),
             'payment_type' => $order->payment_type,
             'payment_type_label' => $order->payment_type === 'dp'
                 ? 'Down Payment (DP 50%)'
                 : 'Full Payment',
+            'settlement' => [
+                'state' => $this->settlementState($order),
+                'proof' => $order->dp_settlement_proof,
+                'proof_url' => $order->dp_settlement_proof
+                    ? asset('storage/'.$order->dp_settlement_proof)
+                    : null,
+                'uploaded_at' => $order->dp_settlement_uploaded_at?->toIso8601String(),
+                'verified_at' => $order->dp_settlement_verified_at?->toIso8601String(),
+            ],
             'payment' => array_merge(
                 ['type' => $order->payment_method_type, 'key' => $order->payment_method_key],
                 $order->payment_data ?? []
@@ -300,17 +422,11 @@ class CheckoutController extends Controller
             'payment_proof_uploaded_at' => now(),
         ]);
 
-        try {
-            Mail::to($order->customer_email)->send(new OrderInvoice($this->buildOrderView($order)));
-        } catch (\Throwable $e) {
-            Log::error('Failed to send invoice email', [
-                'order_id' => $order->order_id,
-                'error' => $e->getMessage(),
-            ]);
-        }
+        // Email invoice/pembayaran diterima dikirim saat admin memverifikasi pembayaran,
+        // bukan saat bukti diunggah. Lihat AdminController::updateStatus.
 
         return redirect()->route('checkout.success', ['orderId' => strtolower($order->order_id)])
             ->with('proof_status', 'success')
-            ->with('proof_message', 'Bukti transfer berhasil diunggah. Invoice telah dikirim ke email kamu.');
+            ->with('proof_message', 'Bukti transfer berhasil diunggah. Admin akan memverifikasi pembayaranmu dan invoice dikirim ke email.');
     }
 }

--- a/app/Mail/OrderInvoice.php
+++ b/app/Mail/OrderInvoice.php
@@ -12,20 +12,29 @@ class OrderInvoice extends Mailable
 {
     use Queueable, SerializesModels;
 
-    public function __construct(public array $order) {}
+    /**
+     * @param  string  $mode  invoice | dp-verified | settlement-received | settlement-verified | reminder
+     */
+    public function __construct(public array $order, public string $mode = 'invoice') {}
 
     public function envelope(): Envelope
     {
-        return new Envelope(
-            subject: 'Invoice Pesanan '.$this->order['id'],
-        );
+        $subject = match ($this->mode) {
+            'dp-verified' => 'DP Diterima — Pelunasan Pesanan '.$this->order['id'],
+            'settlement-received' => 'Bukti Pelunasan Diterima — Pesanan '.$this->order['id'],
+            'settlement-verified' => 'Pembayaran Lunas — Pesanan '.$this->order['id'],
+            'reminder' => 'Pengingat Pelunasan — Pesanan '.$this->order['id'],
+            default => 'Invoice Pesanan '.$this->order['id'],
+        };
+
+        return new Envelope(subject: $subject);
     }
 
     public function content(): Content
     {
         return new Content(
             view: 'emails.order-invoice',
-            with: ['order' => $this->order],
+            with: ['order' => $this->order, 'mode' => $this->mode],
         );
     }
 }

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -18,6 +18,9 @@ class Order extends Model
         'payment_proof_uploaded_at',
         'shipping_tracking',
         'dp_settlement_proof',
+        'dp_settlement_uploaded_at',
+        'dp_settlement_verified_at',
+        'dp_settlement_reminders',
         'item',
         'subtotal',
         'amount_due',
@@ -38,6 +41,9 @@ class Order extends Model
         'verified_at' => 'datetime',
         'completed_at' => 'datetime',
         'payment_proof_uploaded_at' => 'datetime',
+        'dp_settlement_uploaded_at' => 'datetime',
+        'dp_settlement_verified_at' => 'datetime',
+        'dp_settlement_reminders' => 'array',
     ];
 
     public function getRouteKeyName()

--- a/app/Support/OrderPresenter.php
+++ b/app/Support/OrderPresenter.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Order;
+
+class OrderPresenter
+{
+    private const ADMIN_WHATSAPP = '6282298001051';
+
+    private const SHIPPING_LABELS = [
+        'pickup' => 'Ambil di Tempat',
+        'kirim' => 'Kirim (Kurir)',
+    ];
+
+    private const PICKUP_LABELS = [
+        'purwokerto' => 'Purwokerto',
+        'ajibarang' => 'Ajibarang',
+        'jakarta' => 'Jakarta',
+    ];
+
+    /**
+     * Susun array pesanan yang dikonsumsi template email (emails.order-invoice).
+     * Dibangun mandiri dari model Order agar bisa dipakai di luar CheckoutController.
+     */
+    public static function mailData(Order $order): array
+    {
+        return [
+            'id' => $order->order_id,
+            'customer' => [
+                'name' => $order->customer_name,
+                'email' => $order->customer_email,
+                'phone' => $order->customer_phone,
+                'address' => $order->customer_address,
+            ],
+            'shipping' => [
+                'key' => $order->shipping_method,
+                'name' => self::SHIPPING_LABELS[$order->shipping_method] ?? $order->shipping_method,
+                'address' => $order->customer_address,
+                'pickup_location' => $order->pickup_location,
+                'pickup_location_label' => $order->pickup_location
+                    ? (self::PICKUP_LABELS[$order->pickup_location] ?? ucfirst($order->pickup_location))
+                    : null,
+            ],
+            'items' => $order->item ?? [],
+            'subtotal' => (int) $order->subtotal,
+            'amount_due' => (int) $order->amount_due,
+            'remaining' => max(0, (int) $order->subtotal - (int) $order->amount_due),
+            'payment_type' => $order->payment_type,
+            'payment_type_label' => $order->payment_type === 'dp'
+                ? 'Down Payment (DP 50%)'
+                : 'Full Payment',
+            'payment' => array_merge(
+                ['type' => $order->payment_method_type, 'key' => $order->payment_method_key],
+                $order->payment_data ?? []
+            ),
+            'admin_whatsapp' => self::ADMIN_WHATSAPP,
+        ];
+    }
+}

--- a/config/settlement.php
+++ b/config/settlement.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Batas Akhir Pelunasan
+    |--------------------------------------------------------------------------
+    | Tanggal tenggat pelunasan DP. Email pengingat dikirim pada H-7, H-5, H-3,
+    | dan Hari-H (sesuai daftar offset di bawah).
+    */
+    'deadline' => env('SETTLEMENT_DEADLINE', '2026-06-20'),
+
+    /*
+    | Jumlah hari sebelum tenggat untuk mengirim pengingat. 0 = tepat Hari-H.
+    */
+    'reminder_offsets' => [7, 5, 3, 0],
+
+    /*
+    | Jam (zona waktu aplikasi) saat scheduler menjalankan pengiriman pengingat.
+    */
+    'reminder_time' => env('SETTLEMENT_REMINDER_TIME', '08:00'),
+];

--- a/database/migrations/2026_05_31_120000_add_dp_settlement_tracking_to_orders.php
+++ b/database/migrations/2026_05_31_120000_add_dp_settlement_tracking_to_orders.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->timestamp('dp_settlement_uploaded_at')->nullable()->after('dp_settlement_proof');
+            $table->timestamp('dp_settlement_verified_at')->nullable()->after('dp_settlement_uploaded_at');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn(['dp_settlement_uploaded_at', 'dp_settlement_verified_at']);
+        });
+    }
+};

--- a/database/migrations/2026_06_01_100000_add_settlement_reminders_to_orders.php
+++ b/database/migrations/2026_06_01_100000_add_settlement_reminders_to_orders.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            // Daftar tahap reminder pelunasan yang sudah terkirim, mis. ["h-7","h-5"].
+            $table->json('dp_settlement_reminders')->nullable()->after('dp_settlement_verified_at');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn('dp_settlement_reminders');
+        });
+    }
+};

--- a/resources/assets/js/pages/admin-dashboard.js
+++ b/resources/assets/js/pages/admin-dashboard.js
@@ -13,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
         detail: root?.dataset.detailUrl,
         status: root?.dataset.statusUrl,
         syncPayment: root?.dataset.syncPaymentUrl,
+        settlementVerify: root?.dataset.settlementVerifyUrl,
         delete: root?.dataset.deleteUrl,
     };
 
@@ -178,7 +179,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const btn = e.target.closest('button[data-action]');
         if (!btn) return;
         e.preventDefault();
-        const map = { detail: handleDetail, delete: handleDelete, 'sync-payment': handleSyncPayment };
+        const map = { detail: handleDetail, delete: handleDelete, 'sync-payment': handleSyncPayment, 'settlement-verify': handleSettlementVerify };
         map[btn.dataset.action]?.(btn);
     });
 
@@ -409,6 +410,41 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
+    const handleSettlementVerify = async (btn) => {
+        const orderId = btn.dataset.order;
+        if (!endpoints.settlementVerify) return;
+        const result = await Swal.fire({
+            title: 'Verifikasi pelunasan?',
+            html: `Pelunasan DP pesanan <b>${orderId}</b> akan ditandai lunas. Pastikan bukti pembayaran sudah benar.`,
+            icon: 'question',
+            showCancelButton: true,
+            confirmButtonText: 'Ya, verifikasi',
+            cancelButtonText: 'Batal',
+            confirmButtonColor: '#059669',
+        });
+        if (!result.isConfirmed) return;
+
+        try {
+            const res = await fetch(buildUrl(endpoints.settlementVerify, orderId), { method: 'POST', headers });
+            let payload = null;
+            try { payload = await res.json(); } catch (_) {}
+            if (!res.ok || !payload?.ok) throw new Error(payload?.message || 'Gagal memverifikasi pelunasan.');
+            applyStats(payload.stats);
+            toast?.fire({ icon: 'success', title: 'Pelunasan terverifikasi', text: `Pesanan ${orderId} sudah lunas.` });
+            dt.ajax.reload(null, false);
+            const openOrder = detailModalContent?.querySelector('.detail-modal')?.dataset?.order;
+            if (openOrder === orderId) {
+                try {
+                    const r = await fetch(buildUrl(endpoints.detail, openOrder), { headers });
+                    const p = await r.json();
+                    if (p?.ok && detailModalContent) detailModalContent.innerHTML = p.html;
+                } catch (_) {}
+            }
+        } catch (e) {
+            Swal.fire({ icon: 'error', title: 'Gagal', text: e.message });
+        }
+    };
+
     const handleDelete = async (btn) => {
         const orderId = btn.dataset.order;
         const result = await Swal.fire({
@@ -491,7 +527,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const btn = e.target.closest('button[data-action]');
         if (!btn) return;
         closeDropdowns();
-        const map = { detail: handleDetail, status: handleStatus, delete: handleDelete, 'sync-payment': handleSyncPayment };
+        const map = { detail: handleDetail, status: handleStatus, delete: handleDelete, 'sync-payment': handleSyncPayment, 'settlement-verify': handleSettlementVerify };
         map[btn.dataset.action]?.(btn);
     });
 

--- a/resources/views/emails/order-invoice.blade.php
+++ b/resources/views/emails/order-invoice.blade.php
@@ -2,6 +2,25 @@
     $rupiah = fn ($n) => 'Rp' . number_format((int) $n, 0, ',', '.');
     $items = $order['items'] ?? [];
     $shipping = $order['shipping'] ?? null;
+    $mode = $mode ?? 'invoice';
+    $isDp = ($order['payment_type'] ?? null) === 'dp';
+    $remaining = $order['remaining'] ?? max(0, (int) ($order['subtotal'] ?? 0) - (int) ($order['amount_due'] ?? 0));
+    $settlementUrl = route('checkout.settlement', ['orderId' => strtolower($order['id'])]);
+    $reminder = $order['reminder'] ?? null;
+    $deadlineLabel = $reminder['deadline_label'] ?? null;
+    $reminderIntro = $reminder
+        ? (($reminder['is_due'] ?? false)
+            ? 'Hari ini adalah batas akhir pelunasan pesananmu' . ($deadlineLabel ? ' (' . $deadlineLabel . ')' : '') . '. Mohon segera lunasi sisa pembayaran agar pesanan dapat kami proses.'
+            : 'Pengingat: batas pelunasan pesananmu' . ($deadlineLabel ? ' jatuh pada ' . $deadlineLabel : '') . '. Yuk lunasi sisa pembayaran sebelum melewati tenggat.')
+        : 'Pengingat untuk melunasi sisa pembayaran pesananmu.';
+    $headings = [
+        'invoice' => ['eyebrow' => 'INVOICE PESANAN', 'intro' => 'Pembayaran kamu sudah kami verifikasi. Berikut invoice resmi pesananmu:'],
+        'dp-verified' => ['eyebrow' => 'DP DITERIMA', 'intro' => 'Pembayaran DP kamu sudah kami verifikasi. Silakan lunasi sisa pembayaran agar pesananmu dapat segera diproses dan dikirim.'],
+        'settlement-received' => ['eyebrow' => 'BUKTI PELUNASAN DITERIMA', 'intro' => 'Kami sudah menerima bukti pelunasanmu. Tim kami akan segera memverifikasi pembayaran ini.'],
+        'settlement-verified' => ['eyebrow' => 'PEMBAYARAN LUNAS', 'intro' => 'Pelunasan kamu sudah kami verifikasi. Pesananmu kini berstatus LUNAS dan akan segera kami proses. Terima kasih!'],
+        'reminder' => ['eyebrow' => 'PENGINGAT PELUNASAN', 'intro' => $reminderIntro],
+    ];
+    $head = $headings[$mode] ?? $headings['invoice'];
 @endphp
 
 <!DOCTYPE html>
@@ -18,7 +37,7 @@
                     <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="max-width:600px;background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e5e5e5;">
                         <tr>
                             <td style="background:#d84315;background-image:linear-gradient(135deg,#d84315 0%,#f57c00 60%,#ff7043 100%);padding:28px 24px;color:#ffffff;border-bottom:3px solid #ffb380;">
-                                <div style="font-size:12px;letter-spacing:1px;opacity:.85;">INVOICE PESANAN</div>
+                                <div style="font-size:12px;letter-spacing:1px;opacity:.85;">{{ $head['eyebrow'] }}</div>
                                 <div style="font-size:22px;font-weight:bold;margin-top:4px;">{{ $order['id'] }}</div>
                                 <div style="font-size:12px;opacity:.85;margin-top:6px;">{{ config('app.name') }}</div>
                             </td>
@@ -26,7 +45,7 @@
                         <tr>
                             <td style="padding:24px;">
                                 <p style="margin:0 0 12px;font-size:14px;">Halo <strong>{{ $order['customer']['name'] }}</strong>,</p>
-                                <p style="margin:0 0 16px;font-size:13px;line-height:1.6;">Terima kasih, pesananmu sudah kami terima dan akan segera kami proses. Berikut rincian invoice pesananmu:</p>
+                                <p style="margin:0 0 16px;font-size:13px;line-height:1.6;">{{ $head['intro'] }}</p>
                                 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin-top:8px;">
                                     <thead>
                                         <tr>
@@ -56,13 +75,58 @@
                                             <td colspan="2" align="right" style="padding:10px 8px;font-size:12px;color:#666;">{{ $order['payment_type_label'] }}</td>
                                             <td align="right" style="padding:10px 8px;font-size:15px;font-weight:bold;color:#d84315;">{{ $rupiah($order['amount_due']) }}</td>
                                         </tr>
-                                        @if ($order['payment_type'] === 'dp')
+                                        @if ($isDp && in_array($mode, ['dp-verified', 'reminder'], true))
                                         <tr>
-                                            <td colspan="3" style="padding:8px;font-size:11px;color:#777;background:#fafafa;border-radius:6px;">Sisa pembayaran sebesar {{ $rupiah($order['subtotal'] - $order['amount_due']) }} dibayar saat barang siap kirim.</td>
+                                            <td colspan="2" align="right" style="padding:10px 8px;font-size:12px;color:#666;">Sisa Pelunasan</td>
+                                            <td align="right" style="padding:10px 8px;font-size:13px;font-weight:bold;color:#b45309;">{{ $rupiah($remaining) }}</td>
+                                        </tr>
+                                        @elseif ($isDp && $mode === 'settlement-verified')
+                                        <tr>
+                                            <td colspan="2" align="right" style="padding:10px 8px;font-size:12px;color:#666;">Status Pembayaran</td>
+                                            <td align="right" style="padding:10px 8px;font-size:13px;font-weight:bold;color:#047857;">LUNAS</td>
                                         </tr>
                                         @endif
                                     </tfoot>
                                 </table>
+                                @if ($isDp && $remaining > 0 && in_array($mode, ['dp-verified', 'reminder'], true))
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:20px;">
+                                    <tr>
+                                        <td style="padding:16px;background:{{ ($reminder['is_due'] ?? false) ? '#fef2f2' : '#fff7ed' }};border:1px solid {{ ($reminder['is_due'] ?? false) ? '#fecaca' : '#fed7aa' }};border-radius:8px;">
+                                            <div style="font-size:13px;font-weight:bold;color:#b45309;">Lunasi Sisa Pembayaran</div>
+                                            <div style="font-size:12px;color:#92400e;line-height:1.6;margin-top:4px;">
+                                                @if ($mode === 'reminder')
+                                                    @if ($reminder['is_due'] ?? false)
+                                                        <strong>Hari ini batas akhir pelunasan{{ $deadlineLabel ? ' (' . $deadlineLabel . ')' : '' }}.</strong> Lunasi sisa <strong>{{ $rupiah($remaining) }}</strong> sekarang melalui tombol di bawah ini.
+                                                    @else
+                                                        Batas pelunasan{{ $deadlineLabel ? ' jatuh pada ' . $deadlineLabel : '' }}. Lunasi sisa <strong>{{ $rupiah($remaining) }}</strong> melalui tombol di bawah ini sebelum tenggat.
+                                                    @endif
+                                                @else
+                                                    DP kamu sudah diverifikasi. Lunasi sisa <strong>{{ $rupiah($remaining) }}</strong> melalui tombol di bawah ini.
+                                                @endif
+                                            </div>
+                                            <a href="{{ $settlementUrl }}" style="display:inline-block;margin-top:12px;padding:10px 20px;background:#d84315;color:#ffffff;font-size:13px;font-weight:bold;text-decoration:none;border-radius:6px;">Lunasi Sekarang</a>
+                                            <div style="font-size:11px;color:#a16207;margin-top:8px;word-break:break-all;">{{ $settlementUrl }}</div>
+                                        </td>
+                                    </tr>
+                                </table>
+                                @elseif ($mode === 'settlement-received')
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:20px;">
+                                    <tr>
+                                        <td style="padding:16px;background:#ecfdf5;border:1px solid #a7f3d0;border-radius:8px;font-size:12px;color:#047857;line-height:1.6;">
+                                            Bukti pelunasanmu sudah kami terima dan sedang diverifikasi. Kamu akan kami hubungi setelah pembayaran dikonfirmasi.
+                                        </td>
+                                    </tr>
+                                </table>
+                                @elseif ($mode === 'settlement-verified')
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:20px;">
+                                    <tr>
+                                        <td style="padding:16px;background:#ecfdf5;border:1px solid #a7f3d0;border-radius:8px;">
+                                            <div style="font-size:14px;font-weight:bold;color:#047857;">✓ Pembayaran Lunas</div>
+                                            <div style="font-size:12px;color:#047857;line-height:1.6;margin-top:4px;">Total <strong>{{ $rupiah($order['subtotal']) }}</strong> telah kami terima penuh. Pesananmu akan segera diproses{{ ($shipping['key'] ?? null) === 'kirim' ? ' dan dikirim' : '' }}.</div>
+                                        </td>
+                                    </tr>
+                                </table>
+                                @endif
                                 <div style="margin-top:24px;padding:16px;background:#fafafa;border-radius:8px;">
                                     <div style="font-size:12px;color:#666;text-transform:uppercase;letter-spacing:.5px;margin-bottom:8px;">Detail Pemesan</div>
                                     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="font-size:13px;">

--- a/resources/views/pages/admin/dashboard.blade.php
+++ b/resources/views/pages/admin/dashboard.blade.php
@@ -95,6 +95,7 @@
             data-detail-url="{{ url('admin/orders/__ORDER__') }}"
             data-status-url="{{ url('admin/orders/__ORDER__/status') }}"
             data-sync-payment-url="{{ url('admin/orders/__ORDER__/sync-payment') }}"
+            data-settlement-verify-url="{{ url('admin/orders/__ORDER__/settlement-verify') }}"
             data-delete-url="{{ url('admin/orders/__ORDER__') }}">
             <div class="orders-filters grid grid-cols-1 gap-3 border-b border-mercury bg-skull/40 p-4 sm:grid-cols-2 lg:grid-cols-4">
                 <div>

--- a/resources/views/pages/checkout/settlement.blade.php
+++ b/resources/views/pages/checkout/settlement.blade.php
@@ -1,0 +1,269 @@
+@extends('layouts.app')
+
+@php
+    $rupiah = fn ($n) => 'Rp' . number_format((int) $n, 0, ',', '.');
+    $payment = $order['payment'];
+    $isBank = ($payment['type'] ?? null) === 'bank';
+    $isQris = ($payment['type'] ?? null) === 'qris';
+    $items = $order['items'] ?? [];
+    $totalQty = collect($items)->sum('qty');
+    $remaining = $order['remaining'] ?? 0;
+    $settlement = $order['settlement'] ?? [];
+    $state = $settlement['state'] ?? 'locked';
+    $proof = $settlement['proof'] ?? null;
+    $proofUrl = $settlement['proof_url'] ?? null;
+    $proofExt = $proof ? strtolower(pathinfo($proof, PATHINFO_EXTENSION)) : null;
+    $proofIsImage = in_array($proofExt, ['jpg', 'jpeg', 'png', 'webp']);
+    $qrSrc = $isQris && ! empty($payment['image'])
+        ? asset('build/' . $payment['image'])
+        : null;
+
+    $badge = match ($state) {
+        'done' => ['class' => 'badge-emerald', 'icon' => 'ri-checkbox-circle-fill', 'text' => 'Lunas'],
+        'review' => ['class' => 'badge-yellow', 'icon' => 'ri-time-line', 'text' => 'Menunggu Verifikasi'],
+        'locked' => ['class' => 'badge-yellow', 'icon' => 'ri-lock-2-line', 'text' => 'DP Diproses'],
+        default => ['class' => 'badge-yellow', 'icon' => 'ri-wallet-3-line', 'text' => 'Menunggu Pelunasan'],
+    };
+    $canUpload = in_array($state, ['open', 'review'], true);
+@endphp
+
+@section('content')
+    <header class="app-header">
+        <a href="{{ route('home') }}" class="icon-btn">
+            <i class="ri-home-5-line text-lg"></i>
+        </a>
+        <div class="flex-1">
+            <h1 class="app-header__title">Pelunasan</h1>
+            <p class="app-header__subtitle">Lunasi sisa pembayaran DP pesananmu</p>
+        </div>
+        <span class="badge {{ $badge['class'] }}">
+            <i class="{{ $badge['icon'] }}"></i>
+            {{ $badge['text'] }}
+        </span>
+    </header>
+
+    {{-- ==== Sudah lunas ==== --}}
+    @if ($state === 'done')
+    <section class="px-4 pb-6 pt-5">
+        <div class="relative overflow-hidden rounded-2xl bg-linear-to-br from-emerald-500 via-emerald-500 to-emerald-400 p-5 text-white shadow-lg">
+            <span class="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full bg-white/10"></span>
+            <div class="relative flex items-center gap-3">
+                <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-white/20 ring-1 ring-white/30">
+                    <i class="ri-checkbox-circle-fill text-2xl"></i>
+                </span>
+                <div class="flex-1">
+                    <p class="text-[10px] font-semibold uppercase tracking-wider text-white/80">Pembayaran Lunas</p>
+                    <p class="mt-0.5 text-sm font-black leading-snug">Pelunasan pesanan <span class="font-mono">{{ $order['id'] }}</span> sudah kami terima penuh. Terima kasih!</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    {{-- ==== DP belum diverifikasi ==== --}}
+    @elseif ($state === 'locked')
+    <section class="px-4 pb-6 pt-5">
+        <div class="rounded-2xl border border-amber-200 bg-amber-50 p-5">
+            <div class="flex items-center gap-3">
+                <span class="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-white text-amber-600 ring-1 ring-amber-200">
+                    <i class="ri-lock-2-line text-2xl"></i>
+                </span>
+                <div class="flex-1">
+                    <p class="text-xs font-black text-amber-800">DP sedang diverifikasi</p>
+                    <p class="mt-1 text-[11px] leading-snug text-amber-700">Pelunasan baru bisa dilakukan setelah admin memverifikasi pembayaran DP-mu. Kami akan mengirim email begitu DP diterima.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+    @endif
+
+    {{-- ==== Tagihan pelunasan ==== --}}
+    @if ($canUpload)
+    <section class="section">
+        <div class="section-header">
+            <span class="section-bar"></span>
+            <h2 class="section-title">Sisa Pembayaran</h2>
+        </div>
+        <div class="card-skull-lg">
+            <div class="flex items-center justify-between">
+                <div>
+                    <p class="text-[10px] text-onyx">Pelunasan DP 50%</p>
+                    <p class="text-[10px] text-onyx">{{ count($items) }} produk · {{ $totalQty }} item</p>
+                </div>
+                <div class="text-right">
+                    <p class="text-[10px] text-onyx">Sisa yang harus dilunasi</p>
+                    <div class="flex items-center justify-end gap-2">
+                        <span class="text-xl font-black text-primary" data-amount>{{ $rupiah($remaining) }}</span>
+                        <button type="button" class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-white text-foreground ring-1 ring-mercury transition active:scale-95" data-copy="{{ $remaining }}">
+                            <i class="ri-file-copy-line text-xs"></i>
+                        </button>
+                    </div>
+                </div>
+            </div>
+            <div class="mt-3 grid grid-cols-2 gap-2 text-[11px]">
+                <div class="rounded-xl bg-white p-2.5 ring-1 ring-mercury">
+                    <p class="text-[10px] text-onyx">Total Pesanan</p>
+                    <p class="font-bold text-foreground">{{ $rupiah($order['subtotal']) }}</p>
+                </div>
+                <div class="rounded-xl bg-white p-2.5 ring-1 ring-mercury">
+                    <p class="text-[10px] text-onyx">DP Sudah Dibayar</p>
+                    <p class="font-bold text-emerald-600">{{ $rupiah($order['amount_due']) }}</p>
+                </div>
+            </div>
+        </div>
+    </section>
+    <hr class="section-divider">
+    <section class="section">
+        <div class="section-header">
+            <span class="section-bar"></span>
+            <h2 class="section-title">Detail Pembayaran</h2>
+        </div>
+        @if ($isBank)
+        <div class="card">
+            <div class="flex items-center gap-3">
+                <span class="flex h-12 w-16 shrink-0 items-center justify-center rounded-lg {{ $payment['color'] }} text-[11px] font-black uppercase tracking-wider text-white shadow-sm">{{ $payment['logo_text'] }}</span>
+                <div class="flex-1">
+                    <p class="text-xs font-bold text-foreground">{{ $payment['label'] }}</p>
+                    <p class="text-[10px] text-onyx">a.n. {{ $payment['account_name'] }}</p>
+                </div>
+            </div>
+            <div class="mt-3 rounded-xl bg-skull p-3 ring-1 ring-mercury">
+                <p class="text-[10px] font-semibold uppercase tracking-wider text-onyx">Nomor Rekening</p>
+                <div class="mt-1 flex items-center justify-between gap-2">
+                    <span class="text-lg font-black tracking-wider text-foreground" data-account>{{ $payment['account_number'] }}</span>
+                    <button type="button" class="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-[11px] font-bold text-white shadow-sm transition active:scale-95" data-copy="{{ $payment['account_number'] }}">
+                        <i class="ri-file-copy-line text-xs"></i>
+                        Salin
+                    </button>
+                </div>
+            </div>
+            <ol class="mt-3 space-y-1.5 text-[11px] text-onyx">
+                <li class="flex gap-2"><span class="font-bold text-primary">1.</span> Transfer sisa pelunasan sesuai nominal di atas.</li>
+                <li class="flex gap-2"><span class="font-bold text-primary">2.</span> Simpan bukti transfer kamu.</li>
+                <li class="flex gap-2"><span class="font-bold text-primary">3.</span> Upload bukti pelunasan di bawah ini.</li>
+            </ol>
+        </div>
+        @elseif ($isQris)
+        <div class="card">
+            <div class="flex items-center gap-3">
+                <span class="flex h-12 w-16 shrink-0 items-center justify-center rounded-lg bg-sky-500 text-[11px] font-black uppercase tracking-wider text-white shadow-sm">QRIS</span>
+                <div class="flex-1">
+                    <p class="text-xs font-bold text-foreground">{{ $payment['label'] }}</p>
+                    <p class="text-[10px] text-onyx">{{ $payment['merchant'] }}</p>
+                </div>
+            </div>
+            <div class="mt-3 flex flex-col items-center rounded-xl bg-skull p-4 ring-1 ring-mercury">
+                <div class="rounded-2xl bg-white p-3 ring-1 ring-mercury">
+                    <img src="{{ $qrSrc }}" alt="Kode QR Pembayaran" class="h-48 w-48 object-contain" loading="lazy">
+                </div>
+                <a href="{{ $qrSrc }}" download="qris-{{ strtolower($order['id']) }}.{{ pathinfo($payment['image'], PATHINFO_EXTENSION) ?: 'png' }}"
+                    class="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-[11px] font-bold text-white shadow-sm transition active:scale-95 hover:bg-primary/90">
+                    <i class="ri-download-2-line text-xs"></i>
+                    Unduh Kode QR
+                </a>
+                <p class="mt-3 text-center text-[11px] leading-snug text-onyx">Scan kode QR di atas pakai DANA, GoPay, OVO, ShopeePay, atau mobile banking.</p>
+            </div>
+            <ol class="mt-3 space-y-1.5 text-[11px] text-onyx">
+                <li class="flex gap-2"><span class="font-bold text-primary">1.</span> Bayar sesuai nominal sisa pelunasan.</li>
+                <li class="flex gap-2"><span class="font-bold text-primary">2.</span> Simpan struk pembayaran.</li>
+                <li class="flex gap-2"><span class="font-bold text-primary">3.</span> Upload bukti pelunasan di bawah ini.</li>
+            </ol>
+        </div>
+        @endif
+    </section>
+    <hr class="section-divider">
+    <section class="section" id="proof-section">
+        <div class="section-header">
+            <span class="section-bar"></span>
+            <h2 class="section-title">Bukti Pelunasan</h2>
+        </div>
+        @if (session('proof_status') === 'error')
+        <div class="mb-3 flex items-start gap-2 rounded-2xl border border-red-200 bg-red-50 p-3 text-[11px] leading-snug text-red-700">
+            <i class="ri-error-warning-fill shrink-0 text-base"></i>
+            <span>{{ session('proof_message') }}</span>
+        </div>
+        @endif
+        @if (session('proof_status') === 'success')
+        <div class="mb-3 flex items-start gap-2 rounded-2xl border border-emerald-200 bg-emerald-50 p-3 text-[11px] leading-snug text-emerald-700">
+            <i class="ri-checkbox-circle-fill shrink-0 text-base"></i>
+            <span>{{ session('proof_message') }}</span>
+        </div>
+        @endif
+        @if ($state === 'review' && $proof)
+        <div class="card">
+            <div class="flex items-center gap-3">
+                <span class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-emerald-100 text-emerald-600 ring-1 ring-emerald-200">
+                    <i class="ri-shield-check-fill text-xl"></i>
+                </span>
+                <div class="flex-1">
+                    <p class="text-xs font-bold text-foreground">Bukti pelunasan terkirim</p>
+                    <p class="text-[10px] text-onyx">Admin akan memverifikasi pelunasanmu segera.</p>
+                </div>
+            </div>
+            @if ($proofIsImage)
+            <a href="{{ $proofUrl }}" target="_blank" rel="noopener" class="mt-3 block overflow-hidden rounded-xl ring-1 ring-mercury">
+                <img src="{{ $proofUrl }}" class="h-auto w-full object-contain" alt="Bukti Pelunasan" loading="lazy">
+            </a>
+            @else
+            <a href="{{ $proofUrl }}" class="mt-3 flex items-center gap-2 rounded-xl bg-skull p-3 ring-1 ring-mercury" target="_blank" rel="noopener">
+                <i class="ri-file-pdf-2-line text-2xl text-red-500"></i>
+                <span class="flex-1 truncate text-[11px] font-semibold text-foreground">Lihat bukti (PDF)</span>
+                <i class="ri-external-link-line text-base text-onyx"></i>
+            </a>
+            @endif
+            <p class="mt-3 text-[10px] text-onyx">Mau ganti file? Upload ulang di bawah ini.</p>
+        </div>
+        @endif
+        <form action="{{ route('checkout.settlement.proof', ['orderId' => strtolower($order['id'])]) }}" method="post" enctype="multipart/form-data" class="{{ $state === 'review' ? 'mt-3' : '' }}" data-proof-form>
+            @csrf
+            <label for="proof-file" class="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-primary-soft bg-primary-softer p-5 text-center transition hover:bg-primary-softer/80" data-proof-dropzone>
+                <span class="flex h-12 w-12 items-center justify-center rounded-2xl bg-white text-primary ring-1 ring-primary-soft">
+                    <i class="ri-upload-cloud-2-line text-2xl"></i>
+                </span>
+                <span class="text-xs font-bold text-foreground" data-proof-label>{{ $state === 'review' ? 'Ganti bukti pelunasan' : 'Pilih file bukti pelunasan' }}</span>
+                <span class="text-[10px] text-onyx">JPG/PNG/WEBP/PDF · maks 5MB</span>
+                <input type="file" id="proof-file" class="sr-only" name="proof" accept=".jpg,.jpeg,.png,.webp,.pdf,image/*,application/pdf" data-proof-input required>
+            </label>
+            <div class="mt-3 hidden items-center gap-3 rounded-xl bg-white p-3 ring-1 ring-mercury" data-proof-preview>
+                <span class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-skull text-primary ring-1 ring-mercury">
+                    <i class="ri-file-line text-xl" data-proof-preview-icon></i>
+                    <img class="hidden h-full w-full object-cover" alt="" data-proof-preview-image>
+                </span>
+                <div class="min-w-0 flex-1">
+                    <p class="truncate text-xs font-semibold text-foreground" data-proof-preview-name>-</p>
+                    <p class="text-[10px] text-onyx" data-proof-preview-size>-</p>
+                </div>
+                <button type="button" class="icon-btn-xs" data-proof-clear aria-label="Hapus file">
+                    <i class="ri-close-line text-sm"></i>
+                </button>
+            </div>
+            @error('proof')
+            <p class="mt-2 text-[10px] text-red-600">{{ $message }}</p>
+            @enderror
+            <button type="submit" class="btn-primary mt-3 w-full disabled:opacity-50" data-proof-submit disabled>
+                <i class="ri-upload-2-line text-base"></i>
+                <span data-proof-submit-label>Kirim Bukti Pelunasan</span>
+            </button>
+        </form>
+    </section>
+    @endif
+
+    <div class="cta-floating">
+        <div class="cta-floating__inner">
+            <div class="overflow-hidden" data-copy-toast>
+                <div class="toast-panel" data-copy-toast-panel>
+                    <span class="toast-icon-ok">
+                        <i class="ri-check-line text-base"></i>
+                    </span>
+                    <div class="flex-1">
+                        <div class="text-xs font-bold">Berhasil disalin</div>
+                        <p class="mt-0.5 text-[11px] leading-snug text-white/80" data-copy-toast-message>Tempel ke aplikasi pembayaranmu.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('scripts')
+    @vite('resources/assets/js/pages/checkout-success.js')
+@endpush

--- a/resources/views/pages/checkout/success.blade.php
+++ b/resources/views/pages/checkout/success.blade.php
@@ -118,6 +118,21 @@
                 <dd class="font-black text-primary">{{ $rupiah($order['amount_due']) }}</dd>
             </div>
         </dl>
+        @if ($order['payment_type'] === 'dp' && ($order['remaining'] ?? 0) > 0)
+        <div class="mt-3 rounded-2xl border border-dashed border-amber-300 bg-amber-50 p-4">
+            <div class="flex items-start gap-2">
+                <i class="ri-wallet-3-line shrink-0 text-base text-amber-600"></i>
+                <div class="flex-1">
+                    <p class="text-[11px] font-bold text-amber-800">Sisa pelunasan {{ $rupiah($order['remaining']) }}</p>
+                    <p class="mt-0.5 text-[10px] leading-snug text-amber-700">Setelah DP diverifikasi admin, kamu bisa melunasi sisa pembayaran lewat halaman pelunasan. Link juga kami kirim ke emailmu.</p>
+                </div>
+            </div>
+            <a href="{{ route('checkout.settlement', ['orderId' => strtolower($order['id'])]) }}" class="mt-3 inline-flex w-full items-center justify-center gap-1.5 rounded-lg bg-amber-500 px-3 py-2 text-[11px] font-bold text-white shadow-sm transition active:scale-95 hover:bg-amber-600">
+                <i class="ri-arrow-right-circle-line text-sm"></i>
+                Buka Halaman Pelunasan
+            </a>
+        </div>
+        @endif
     </section>
     <div class="cta-floating">
         <div class="pointer-events-auto mx-auto max-w-480 cta-card">

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,13 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+// Pengingat pelunasan DP (H-7, H-5, H-3, Hari-H sebelum tenggat).
+Schedule::command('orders:settlement-reminders')
+    ->dailyAt(config('settlement.reminder_time', '08:00'))
+    ->withoutOverlapping();

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,8 @@ Route::post('/checkout', [CheckoutController::class, 'store'])->name('checkout.s
 Route::get('/pembayaran/{orderId}', [CheckoutController::class, 'payment'])->name('checkout.payment');
 Route::post('/pembayaran/{orderId}/bukti', [CheckoutController::class, 'uploadProof'])->name('checkout.proof');
 Route::get('/terimakasih/{orderId}', [CheckoutController::class, 'success'])->name('checkout.success');
+Route::get('/pelunasan/{orderId}', [CheckoutController::class, 'settlement'])->name('checkout.settlement');
+Route::post('/pelunasan/{orderId}/bukti', [CheckoutController::class, 'uploadSettlement'])->name('checkout.settlement.proof');
 
 Route::middleware('auth')->prefix('admin')->name('admin.')->group(function () {
     Route::get('/', [AdminController::class, 'dashboard'])->name('dashboard');
@@ -21,6 +23,7 @@ Route::middleware('auth')->prefix('admin')->name('admin.')->group(function () {
     Route::post('/orders/{order}/status', [AdminController::class, 'updateStatus'])->name('orders.status');
     Route::post('/orders/{order}/shipping', [AdminController::class, 'updateShipping'])->name('orders.shipping');
     Route::post('/orders/{order}/dp-proof', [AdminController::class, 'uploadDpProof'])->name('orders.dp-proof');
+    Route::post('/orders/{order}/settlement-verify', [AdminController::class, 'verifySettlement'])->name('orders.settlement-verify');
     Route::post('/orders/{order}/sync-payment', [AdminController::class, 'syncPayment'])->name('orders.sync-payment');
     Route::delete('/orders/{order}', [AdminController::class, 'destroyOrder'])->name('orders.destroy');
 });


### PR DESCRIPTION
## Summary

Adds a complete self-service **DP 50% settlement (pelunasan)** flow with admin verification, moves invoice/paid emails to the moment of admin verification, and introduces a scheduler that emails settlement reminders before the deadline.

## Changes

- [x] feat: self-service DP 50% settlement page (`/pelunasan/{orderId}`) showing the remaining balance, payment method, and proof upload — with `locked` / `open` / `review` / `done` states
- [x] feat: admin verification of settlement proof, gating order completion on `dp_settlement_verified_at` (with a "Verify Settlement" action in the dashboard)
- [x] feat: send the invoice / payment-received email when the admin **verifies** the payment (DP → settlement call-to-action, full → invoice) instead of on proof upload
- [x] feat: automatically send a "fully paid" email when the settlement is verified by the admin
- [x] feat: settlement reminder scheduler that emails customers at **H-7, H-5, H-3, and the due date** before the deadline (default `2026-06-20`, configurable)

## Details

- **Customer flow:** pay DP → admin verifies DP → customer pays the remaining balance on `/pelunasan/{orderId}` and uploads proof → admin verifies settlement → order can be completed.
- **Emails** share one template (`emails/order-invoice.blade.php`) with five modes: `invoice`, `dp-verified`, `settlement-received`, `settlement-verified`, `reminder` (distinct subject, banner, and CTA per mode).
- **`OrderPresenter`** builds the email payload directly from the `Order` model so it can be reused outside the checkout controller (e.g. the scheduler and admin actions).
- **Reminder command** `orders:settlement-reminders` targets verified, unsettled DP orders with a remaining balance; it is **idempotent per stage** via the `dp_settlement_reminders` column and is scheduled daily at 08:00.

## Database

- `2026_05_31_120000_add_dp_settlement_tracking_to_orders` — adds `dp_settlement_uploaded_at`, `dp_settlement_verified_at`
- `2026_06_01_100000_add_settlement_reminders_to_orders` — adds `dp_settlement_reminders` (JSON)

## Testing

- PHP lint, `migrate`, and Blade compilation pass.
- Email rendering verified for all five modes.
- Settlement page renders 200 with the upload form for the `open` state (and correct redirects/states otherwise).
- Reminder command verified with `Mail::fake()`: correct stage detection (H-7/H-5/H-3/Hari-H), idempotency, and no-op on non-stage days. Test data was reset afterwards.

## Notes

- For the scheduler to run in production, the Laravel cron entry must be active:
  ```cron
  * * * * * cd /path/to/jakpurwokerto && php artisan schedule:run >> /dev/null 2>&1
