### PR TITLE
Release v3.4.1

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -57,13 +57,18 @@ class AdminController extends Controller
 
     private function orderStats(): array
     {
+        $confirmed = ['verified', 'paid', 'shipped', 'completed'];
+
         return [
             'total' => Order::count(),
             'pending' => Order::where('status', 'pending')->count(),
             'verified' => Order::where('status', 'verified')->count(),
+            'paid' => Order::where('status', 'paid')->count(),
+            'shipped' => Order::where('status', 'shipped')->count(),
             'completed' => Order::where('status', 'completed')->count(),
             'cancelled' => Order::where('status', 'cancelled')->count(),
-            'revenue' => Order::where('status', 'verified')->sum('amount_due'),
+            'confirmed' => Order::whereIn('status', $confirmed)->count(),
+            'revenue' => Order::whereIn('status', $confirmed)->sum('amount_due'),
         ];
     }
 
@@ -97,6 +102,11 @@ class AdminController extends Controller
                 'diverifikasi' => 'verified',
                 'verified' => 'verified',
                 'verifikasi' => 'verified',
+                'lunas' => 'paid',
+                'paid' => 'paid',
+                'dikirim' => 'shipped',
+                'shipped' => 'shipped',
+                'siap diambil' => 'shipped',
                 'selesai' => 'completed',
                 'completed' => 'completed',
                 'batal' => 'cancelled',
@@ -147,7 +157,7 @@ class AdminController extends Controller
         }
 
         $statusFilter = $request->input('filter_status');
-        if (in_array($statusFilter, ['pending', 'verified', 'completed', 'cancelled'], true)) {
+        if (in_array($statusFilter, ['pending', 'verified', 'paid', 'shipped', 'completed', 'cancelled'], true)) {
             $query->where('status', $statusFilter);
         }
 
@@ -178,6 +188,8 @@ class AdminController extends Controller
         $statusLabels = [
             'pending' => 'Menunggu Pembayaran',
             'verified' => 'Pembayaran Diterima',
+            'paid' => 'Lunas',
+            'shipped' => 'Dikirim',
             'completed' => 'Selesai',
             'cancelled' => 'Dibatalkan',
         ];
@@ -296,7 +308,7 @@ class AdminController extends Controller
     public function updateStatus(Request $request, Order $order)
     {
         $validated = $request->validate([
-            'status' => ['required', 'in:pending,verified,completed,cancelled'],
+            'status' => ['required', 'in:pending,verified,paid,shipped,completed,cancelled'],
         ]);
 
         $next = $validated['status'];
@@ -304,7 +316,9 @@ class AdminController extends Controller
 
         $allowed = match ($current) {
             'pending' => ['verified', 'cancelled'],
-            'verified' => ['completed', 'cancelled', 'pending'],
+            'verified' => ['paid', 'cancelled', 'pending'],
+            'paid' => ['shipped', 'cancelled'],
+            'shipped' => ['completed', 'cancelled'],
             'completed' => [],
             'cancelled' => ['pending'],
             default => [],
@@ -317,38 +331,45 @@ class AdminController extends Controller
             ], 422);
         }
 
-        if ($next === 'completed' && $order->shipping_method === 'kirim' && empty($order->shipping_tracking)) {
+        // Full payment sudah lunas sejak awal → langsung 'paid' saat pembayaran diverifikasi.
+        if ($next === 'verified' && $order->payment_type === 'full') {
+            $next = 'paid';
+        }
+
+        // DP hanya bisa 'paid' jika pelunasannya sudah diverifikasi.
+        if ($next === 'paid' && $order->payment_type === 'dp' && empty($order->dp_settlement_verified_at)) {
             return response()->json([
                 'ok' => false,
-                'message' => 'Input nomor resi terlebih dahulu sebelum menandai selesai.',
+                'message' => 'Verifikasi pelunasan DP terlebih dahulu.',
             ], 422);
         }
 
-        if ($next === 'completed' && $order->payment_type === 'dp' && empty($order->dp_settlement_verified_at)) {
+        // Pesanan kirim wajib punya nomor resi sebelum ditandai dikirim.
+        if ($next === 'shipped' && $order->shipping_method === 'kirim' && empty($order->shipping_tracking)) {
             return response()->json([
                 'ok' => false,
-                'message' => 'Verifikasi pelunasan DP terlebih dahulu sebelum menandai selesai.',
+                'message' => 'Input nomor resi terlebih dahulu sebelum menandai dikirim.',
             ], 422);
         }
 
-        $wasVerified = $order->status === 'verified';
+        $prev = $order->status;
 
         $order->status = $next;
-        $order->verified_at = $next === 'verified' ? ($order->verified_at ?? now()) : ($next === 'pending' ? null : $order->verified_at);
-        $order->completed_at = $next === 'completed' ? now() : null;
+        if (in_array($next, ['verified', 'paid', 'shipped', 'completed'], true)) {
+            $order->verified_at = $order->verified_at ?? now();
+        } elseif ($next === 'pending') {
+            $order->verified_at = null;
+        }
+        $order->completed_at = $next === 'completed' ? now() : ($next === 'pending' ? null : $order->completed_at);
         $order->save();
 
-        // Pembayaran baru diverifikasi admin → kirim email invoice/pembayaran diterima.
-        if ($next === 'verified' && ! $wasVerified) {
-            $hasRemaining = (int) $order->subtotal - (int) $order->amount_due > 0;
-
-            if ($order->payment_type === 'dp' && empty($order->dp_settlement_verified_at) && $hasRemaining) {
-                // DP diterima → ajakan pelunasan.
-                $this->sendOrderMail($order, 'dp-verified');
-            } else {
-                // Pembayaran penuh (atau DP tanpa sisa) → invoice pembayaran diterima.
-                $this->sendOrderMail($order, 'invoice');
-            }
+        // Email transaksional sesuai status baru.
+        if ($next === 'verified' && $prev !== 'verified' && $order->payment_type === 'dp') {
+            // DP diterima → ajakan pelunasan.
+            $this->sendOrderMail($order, 'dp-verified');
+        } elseif ($next === 'paid' && $prev !== 'paid' && $order->payment_type === 'full') {
+            // Full payment diverifikasi → invoice pembayaran diterima.
+            $this->sendOrderMail($order, 'invoice');
         }
 
         return response()->json([
@@ -426,11 +447,16 @@ class AdminController extends Controller
 
         $path = $validated['proof']->store('proofs/settlements', 'public');
         $alreadyVerified = (bool) $order->dp_settlement_verified_at;
-        $order->update([
+        $update = [
             'dp_settlement_proof' => $path,
             'dp_settlement_uploaded_at' => $order->dp_settlement_uploaded_at ?? now(),
             'dp_settlement_verified_at' => now(),
-        ]);
+        ];
+        // Pelunasan terverifikasi → naikkan status ke 'paid' (lunas).
+        if ($order->status === 'verified') {
+            $update['status'] = 'paid';
+        }
+        $order->update($update);
 
         if (! $alreadyVerified) {
             $this->sendOrderMail($order, 'settlement-verified');
@@ -457,7 +483,13 @@ class AdminController extends Controller
             return response()->json(['ok' => false, 'message' => 'Pelunasan sudah diverifikasi.'], 422);
         }
 
-        $order->update(['dp_settlement_verified_at' => now()]);
+        $update = ['dp_settlement_verified_at' => now()];
+        // Pelunasan terverifikasi → naikkan status ke 'paid' (lunas).
+        if ($order->status === 'verified') {
+            $update['status'] = 'paid';
+            $order->verified_at = $order->verified_at ?? now();
+        }
+        $order->update($update);
 
         $this->sendOrderMail($order, 'settlement-verified');
 
@@ -493,7 +525,7 @@ class AdminController extends Controller
 
     private function serializeOrder(Order $order): array
     {
-        $statusMeta = $this->statusMeta($order->status);
+        $statusMeta = $this->statusMeta($order->status, $order->shipping_method);
         $payment = $this->paymentLabel($order);
 
         $amountHtml = '<div class="font-bold text-foreground">Rp'.number_format($order->amount_due, 0, ',', '.').'</div>';
@@ -528,11 +560,15 @@ class AdminController extends Controller
         ];
     }
 
-    private function statusMeta(string $status): array
+    private function statusMeta(string $status, ?string $shippingMethod = null): array
     {
+        $shippedLabel = $shippingMethod === 'pickup' ? 'Siap Diambil' : 'Dikirim';
+
         return [
             'pending' => ['label' => 'Menunggu Pembayaran', 'class' => 'bg-amber-100 text-amber-700', 'icon' => 'ri-time-line'],
             'verified' => ['label' => 'Pembayaran Diterima', 'class' => 'bg-emerald-100 text-emerald-700', 'icon' => 'ri-shield-check-line'],
+            'paid' => ['label' => 'Lunas', 'class' => 'bg-teal-100 text-teal-700', 'icon' => 'ri-money-dollar-circle-line'],
+            'shipped' => ['label' => $shippedLabel, 'class' => 'bg-blue-100 text-blue-700', 'icon' => 'ri-truck-line'],
             'completed' => ['label' => 'Selesai', 'class' => 'bg-sky-100 text-sky-700', 'icon' => 'ri-flag-line'],
             'cancelled' => ['label' => 'Dibatalkan', 'class' => 'bg-red-100 text-red-700', 'icon' => 'ri-close-circle-line'],
         ][$status] ?? ['label' => ucfirst($status), 'class' => 'bg-gray-100 text-gray-700', 'icon' => 'ri-question-line'];
@@ -583,7 +619,7 @@ class AdminController extends Controller
     private function countSoldForSlug(string $slug): int
     {
         $sold = 0;
-        Order::whereIn('status', ['verified', 'completed'])
+        Order::whereIn('status', ['verified', 'paid', 'shipped', 'completed'])
             ->select(['item'])
             ->chunk(200, function ($orders) use (&$sold, $slug) {
                 foreach ($orders as $order) {
@@ -600,7 +636,7 @@ class AdminController extends Controller
 
     private function renderDetail(Order $order): string
     {
-        $statusMeta = $this->statusMeta($order->status);
+        $statusMeta = $this->statusMeta($order->status, $order->shipping_method);
         $payment = $this->paymentLabel($order);
         $rupiah = fn ($n) => 'Rp'.number_format((int) $n, 0, ',', '.');
 
@@ -682,7 +718,11 @@ class AdminController extends Controller
         ];
 
         if ($order->shipping_method === 'kirim') {
-            $shipAddrHtml = $field('Alamat Pengiriman', nl2br(e($order->customer_address ?? '-')), 'ri-map-pin-2-line');
+            $resiValue = $order->shipping_tracking
+                ? '<span class="font-mono font-bold text-foreground">'.e($order->shipping_tracking).'</span>'
+                : '<span class="text-amber-700">Belum ada resi</span>';
+            $shipAddrHtml = $field('Alamat Pengiriman', nl2br(e($order->customer_address ?? '-')), 'ri-map-pin-2-line')
+                .$field('Nomor Resi (JNT)', $resiValue, 'ri-barcode-line');
             $shipNoteHtml = $field('Kurir', 'JNT Express (ongkos kirim ditanggung pembeli)', 'ri-truck-line');
         } else {
             $cityKey = $order->pickup_location ?? '';
@@ -866,6 +906,25 @@ class AdminController extends Controller
             && $order->status !== 'cancelled') {
             $items .= '<button type="button" role="menuitem" data-action="settlement-verify" data-order="'.$orderId.'" class="dropdown-item dropdown-item--success">'
                 .'<i class="ri-shield-check-line"></i><span>Verifikasi Pelunasan</span>'
+                .'</button>';
+        }
+
+        if ($order->shipping_method === 'kirim' && in_array($order->status, ['paid', 'shipped'], true)) {
+            $items .= '<button type="button" role="menuitem" data-action="shipping" data-order="'.$orderId.'" data-tracking="'.e($order->shipping_tracking ?? '').'" class="dropdown-item dropdown-item--info">'
+                .'<i class="ri-barcode-line"></i><span>'.($order->shipping_tracking ? 'Ubah Nomor Resi' : 'Input Nomor Resi').'</span>'
+                .'</button>';
+        }
+
+        if ($order->status === 'paid') {
+            $shipLabel = $order->shipping_method === 'pickup' ? 'Tandai Siap Diambil' : 'Tandai Dikirim';
+            $items .= '<button type="button" role="menuitem" data-action="status" data-status="shipped" data-order="'.$orderId.'" class="dropdown-item dropdown-item--info">'
+                .'<i class="ri-truck-line"></i><span>'.$shipLabel.'</span>'
+                .'</button>';
+        }
+
+        if ($order->status === 'shipped') {
+            $items .= '<button type="button" role="menuitem" data-action="status" data-status="completed" data-order="'.$orderId.'" class="dropdown-item dropdown-item--success">'
+                .'<i class="ri-flag-line"></i><span>Tandai Selesai</span>'
                 .'</button>';
         }
 

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -190,7 +190,8 @@ class CheckoutController extends Controller
         if ($order->status === 'cancelled') {
             return 'cancelled';
         }
-        if ($order->dp_settlement_verified_at || $order->status === 'completed'
+        if ($order->dp_settlement_verified_at
+            || in_array($order->status, ['paid', 'shipped', 'completed'], true)
             || (int) $order->subtotal - (int) $order->amount_due <= 0) {
             return 'done';
         }
@@ -345,7 +346,7 @@ class CheckoutController extends Controller
                 ->with('status', 'Pesanan tidak ditemukan.');
         }
 
-        if (in_array($order->status, ['verified', 'cancelled'], true)) {
+        if (in_array($order->status, ['verified', 'paid', 'shipped', 'completed', 'cancelled'], true)) {
             return $this->redirectClosedOrder($order);
         }
 
@@ -399,7 +400,7 @@ class CheckoutController extends Controller
                 ->with('proof_message', 'Pesanan tidak ditemukan.');
         }
 
-        if (in_array($order->status, ['verified', 'cancelled'], true)) {
+        if (in_array($order->status, ['verified', 'paid', 'shipped', 'completed', 'cancelled'], true)) {
             return $this->redirectClosedOrder($order);
         }
 

--- a/database/migrations/2026_06_01_140000_expand_order_status_flow.php
+++ b/database/migrations/2026_06_01_140000_expand_order_status_flow.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        DB::statement("ALTER TABLE orders MODIFY status ENUM('pending','verified','paid','shipped','completed','cancelled') NOT NULL DEFAULT 'pending'");
+
+        // Order full payment yang sudah 'verified' = sudah lunas → naikkan ke 'paid'.
+        DB::table('orders')
+            ->where('status', 'verified')
+            ->where('payment_type', 'full')
+            ->update(['status' => 'paid']);
+    }
+
+    public function down()
+    {
+        // Petakan status baru kembali ke skema lama sebelum mengecilkan ENUM.
+        DB::table('orders')->whereIn('status', ['paid', 'shipped'])->update(['status' => 'verified']);
+
+        DB::statement("ALTER TABLE orders MODIFY status ENUM('pending','verified','completed','cancelled') NOT NULL DEFAULT 'pending'");
+    }
+};

--- a/resources/assets/js/pages/admin-dashboard.js
+++ b/resources/assets/js/pages/admin-dashboard.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
         status: root?.dataset.statusUrl,
         syncPayment: root?.dataset.syncPaymentUrl,
         settlementVerify: root?.dataset.settlementVerifyUrl,
+        shipping: root?.dataset.shippingUrl,
         delete: root?.dataset.deleteUrl,
     };
 
@@ -179,7 +180,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const btn = e.target.closest('button[data-action]');
         if (!btn) return;
         e.preventDefault();
-        const map = { detail: handleDetail, delete: handleDelete, 'sync-payment': handleSyncPayment, 'settlement-verify': handleSettlementVerify };
+        const map = { detail: handleDetail, status: handleStatus, delete: handleDelete, 'sync-payment': handleSyncPayment, 'settlement-verify': handleSettlementVerify, shipping: handleShipping };
         map[btn.dataset.action]?.(btn);
     });
 
@@ -335,6 +336,75 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    // ===== Shipping (Resi) Modal =====
+    const shippingModal = document.getElementById('shipping-modal');
+    const shippingForm = shippingModal?.querySelector('[data-shipping-form]');
+    const shippingInput = shippingModal?.querySelector('[data-shipping-input]');
+    const shippingError = shippingModal?.querySelector('[data-shipping-error]');
+    const shippingSubmit = shippingModal?.querySelector('[data-shipping-submit]');
+    const shippingOrderIdEl = shippingModal?.querySelector('[data-shipping-order-id]');
+    const shippingState = { orderId: null };
+    let shippingLastTrigger = null;
+
+    const openShippingModal = (orderId, tracking, trigger) => {
+        if (!shippingModal) return;
+        shippingState.orderId = orderId;
+        shippingLastTrigger = trigger || null;
+        if (shippingOrderIdEl) shippingOrderIdEl.textContent = orderId;
+        if (shippingInput) shippingInput.value = tracking || '';
+        if (shippingError) shippingError.classList.add('hidden');
+        if (shippingSubmit) shippingSubmit.disabled = false;
+        shippingModal.hidden = false;
+        shippingModal.removeAttribute('aria-hidden');
+        document.body.style.overflow = 'hidden';
+        setTimeout(() => shippingInput?.focus({ preventScroll: true }), 30);
+    };
+
+    const closeShippingModal = () => {
+        if (!shippingModal || shippingModal.hidden) return;
+        shippingModal.hidden = true;
+        shippingModal.setAttribute('aria-hidden', 'true');
+        if (!detailModal || detailModal.hidden) document.body.style.overflow = '';
+        shippingLastTrigger?.focus({ preventScroll: true });
+        shippingLastTrigger = null;
+    };
+
+    shippingModal?.querySelectorAll('[data-shipping-close]').forEach((el) => {
+        el.addEventListener('click', closeShippingModal);
+    });
+
+    const handleShipping = (btn) => {
+        if (!endpoints.shipping) return;
+        openShippingModal(btn.dataset.order, btn.dataset.tracking || '', btn);
+    };
+
+    shippingForm?.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        if (!shippingState.orderId || !endpoints.shipping) return;
+        const value = (shippingInput?.value || '').trim();
+        if (!value) {
+            if (shippingError) { shippingError.textContent = 'Nomor resi wajib diisi.'; shippingError.classList.remove('hidden'); }
+            return;
+        }
+
+        if (shippingSubmit) shippingSubmit.disabled = true;
+        try {
+            const fd = new FormData();
+            fd.append('tracking', value);
+            const res = await fetch(buildUrl(endpoints.shipping, shippingState.orderId), { method: 'POST', headers, body: fd });
+            let payload = null;
+            try { payload = await res.json(); } catch (_) {}
+            if (!res.ok || !payload?.ok) throw new Error(payload?.message || 'Gagal menyimpan resi.');
+            toast?.fire({ icon: 'success', title: 'Resi tersimpan', text: `Pesanan ${shippingState.orderId} diperbarui.` });
+            dt.ajax.reload(null, false);
+            await refreshOpenDetail(shippingState.orderId);
+            closeShippingModal();
+        } catch (err) {
+            if (shippingError) { shippingError.textContent = err.message; shippingError.classList.remove('hidden'); }
+            if (shippingSubmit) shippingSubmit.disabled = false;
+        }
+    });
+
     const handleDetail = async (btn) => {
         const orderId = btn.dataset.order;
         lastTrigger = btn;
@@ -346,6 +416,17 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (e) {
             Swal.fire({ icon: 'error', title: 'Gagal', text: e.message });
         }
+    };
+
+    // Muat ulang isi modal detail bila pesanan yang sedang dibuka == orderId.
+    const refreshOpenDetail = async (orderId) => {
+        const openOrder = detailModalContent?.querySelector('.detail-modal')?.dataset?.order;
+        if (!openOrder || openOrder !== orderId) return;
+        try {
+            const r = await fetch(buildUrl(endpoints.detail, openOrder), { headers });
+            const p = await r.json();
+            if (p?.ok && detailModalContent) detailModalContent.innerHTML = p.html;
+        } catch (_) {}
     };
 
     const toast = createToast();
@@ -377,6 +458,21 @@ document.addEventListener('DOMContentLoaded', () => {
                 text: 'Pembayaran pesanan akan ditandai sudah diterima dan terhitung ke stok dan pendapatan.',
                 icon: 'question',
                 confirmText: 'Ya, diterima',
+                toast: 'Pembayaran berhasil diterima.',
+            },
+            shipped: {
+                title: 'Tandai pesanan dikirim?',
+                text: 'Pesanan akan ditandai dikirim / siap diambil. Untuk pesanan kirim, pastikan nomor resi sudah diisi.',
+                icon: 'question',
+                confirmText: 'Ya, lanjut',
+                toast: 'Pesanan ditandai dikirim.',
+            },
+            completed: {
+                title: 'Tandai pesanan selesai?',
+                text: 'Pesanan akan ditandai SELESAI. Pastikan pembayaran lunas dan (untuk pesanan kirim) nomor resi sudah diisi.',
+                icon: 'question',
+                confirmText: 'Ya, selesai',
+                toast: 'Pesanan ditandai selesai.',
             },
         };
         const cfg = confirmMap[status];
@@ -403,8 +499,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 throw new Error(payload?.message || 'Terjadi kesalahan.');
             }
             applyStats(payload.stats);
-            toast?.fire({ icon: 'success', title: 'Status diperbarui', text: 'Pembayaran berhasil diterima.' });
+            toast?.fire({ icon: 'success', title: 'Status diperbarui', text: cfg.toast });
             dt.ajax.reload(null, false);
+            await refreshOpenDetail(orderId);
         } catch (e) {
             Swal.fire({ icon: 'error', title: 'Gagal', text: e.message });
         }
@@ -527,7 +624,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const btn = e.target.closest('button[data-action]');
         if (!btn) return;
         closeDropdowns();
-        const map = { detail: handleDetail, status: handleStatus, delete: handleDelete, 'sync-payment': handleSyncPayment, 'settlement-verify': handleSettlementVerify };
+        const map = { detail: handleDetail, status: handleStatus, delete: handleDelete, 'sync-payment': handleSyncPayment, 'settlement-verify': handleSettlementVerify, shipping: handleShipping };
         map[btn.dataset.action]?.(btn);
     });
 

--- a/resources/views/pages/admin/dashboard.blade.php
+++ b/resources/views/pages/admin/dashboard.blade.php
@@ -28,7 +28,7 @@
         </div>
         <div class="rounded-xl border border-mercury bg-white p-4">
             <p class="text-[10px] font-semibold uppercase tracking-wider text-onyx">Pembayaran Diterima</p>
-            <p class="mt-1.5 text-xl font-black text-emerald-600" data-stat="verified">{{ number_format($stats['verified']) }}</p>
+            <p class="mt-1.5 text-xl font-black text-emerald-600" data-stat="confirmed">{{ number_format($stats['confirmed']) }}</p>
         </div>
         <div class="col-span-2 rounded-xl bg-linear-to-br from-primary via-primary-light to-primary-lighter p-4 text-white sm:col-span-3 lg:col-span-1">
             <p class="text-[10px] font-semibold uppercase tracking-wider text-white/80">Total Pendapatan</p>
@@ -96,6 +96,7 @@
             data-status-url="{{ url('admin/orders/__ORDER__/status') }}"
             data-sync-payment-url="{{ url('admin/orders/__ORDER__/sync-payment') }}"
             data-settlement-verify-url="{{ url('admin/orders/__ORDER__/settlement-verify') }}"
+            data-shipping-url="{{ url('admin/orders/__ORDER__/shipping') }}"
             data-delete-url="{{ url('admin/orders/__ORDER__') }}">
             <div class="orders-filters grid grid-cols-1 gap-3 border-b border-mercury bg-skull/40 p-4 sm:grid-cols-2 lg:grid-cols-4">
                 <div>
@@ -112,6 +113,8 @@
                         <option value="">Semua Status</option>
                         <option value="pending">Menunggu Pembayaran</option>
                         <option value="verified">Pembayaran Diterima</option>
+                        <option value="paid">Lunas</option>
+                        <option value="shipped">Dikirim</option>
                         <option value="completed">Selesai</option>
                         <option value="cancelled">Dibatalkan</option>
                     </select>
@@ -239,6 +242,44 @@
                         <button type="button" data-sync-close class="inline-flex h-10 items-center justify-center gap-1.5 rounded-lg border border-mercury bg-white px-4 text-[13px] font-semibold text-foreground transition hover:bg-skull">Batal</button>
                         <button type="submit" data-sync-submit class="inline-flex h-10 items-center justify-center gap-1.5 rounded-lg bg-primary px-4 text-[13px] font-bold text-white shadow-sm transition hover:bg-primary-light disabled:cursor-not-allowed disabled:opacity-60">
                             <i class="ri-save-3-line"></i> Simpan Perubahan
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div id="shipping-modal" class="order-modal" hidden aria-hidden="true">
+        <div class="order-modal__backdrop" data-shipping-close></div>
+        <div class="order-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="shipping-modal-title">
+            <button type="button" class="order-modal__close" data-shipping-close aria-label="Tutup">
+                <i class="ri-close-line"></i>
+            </button>
+            <div class="order-modal__body">
+                <div class="detail-hero">
+                    <div class="detail-hero__bg"></div>
+                    <div class="relative flex flex-col gap-2 pr-12">
+                        <span class="detail-chip detail-chip--glass w-fit font-mono"><i class="ri-truck-line"></i> <span data-shipping-order-id>—</span></span>
+                        <h2 id="shipping-modal-title" class="text-base font-black leading-tight text-white">Nomor Resi Pengiriman</h2>
+                        <p class="text-[12px] leading-relaxed text-white/85">Masukkan nomor resi JNT Express. Resi wajib diisi sebelum pesanan kirim bisa ditandai selesai.</p>
+                    </div>
+                </div>
+
+                <form data-shipping-form class="flex flex-col gap-4 px-5 py-5">
+                    <div>
+                        <label for="shipping-tracking-input" class="mb-1.5 block text-[11px] font-bold uppercase tracking-wider text-onyx">Nomor Resi</label>
+                        <div class="group relative">
+                            <span class="pointer-events-none absolute inset-y-0 left-0 flex w-12 items-center justify-center border-r border-mercury text-[15px] text-onyx"><i class="ri-barcode-line"></i></span>
+                            <input id="shipping-tracking-input" type="text" autocomplete="off" maxlength="100" data-shipping-input placeholder="Cth. JX1234567890"
+                                class="h-12 w-full rounded-xl border border-mercury bg-white pl-14 pr-4 text-[15px] font-bold tracking-wide text-foreground outline-none transition focus:border-primary focus:ring-2 focus:ring-primary/20" />
+                        </div>
+                        <p class="mt-1.5 hidden text-[11px] font-semibold text-red-600" data-shipping-error></p>
+                    </div>
+
+                    <div class="-mx-5 -mb-5 mt-1 flex items-center justify-end gap-2 border-t border-mercury bg-skull/40 px-5 py-3">
+                        <button type="button" data-shipping-close class="inline-flex h-10 items-center justify-center gap-1.5 rounded-lg border border-mercury bg-white px-4 text-[13px] font-semibold text-foreground transition hover:bg-skull">Batal</button>
+                        <button type="submit" data-shipping-submit class="inline-flex h-10 items-center justify-center gap-1.5 rounded-lg bg-primary px-4 text-[13px] font-bold text-white shadow-sm transition hover:bg-primary-light disabled:cursor-not-allowed disabled:opacity-60">
+                            <i class="ri-save-3-line"></i> Simpan Resi
                         </button>
                     </div>
                 </form>


### PR DESCRIPTION
## Summary

Expands the order lifecycle with two intermediate statuses — **`paid`** and **`shipped`** — so that `completed` is reserved for the final stage (item actually picked up / received). Also adds the admin dashboard actions needed to drive an order through the full lifecycle (mark shipped/ready, input tracking number, mark completed).

## Order lifecycle

pending → verified → paid → shipped → completed   (+ cancelled)


- **DP orders:** `pending` →[Confirm Payment]→ `verified` →[Verify Settlement]→ `paid` →[Mark Shipped, requires tracking for delivery]→ `shipped` →[Mark Completed]→ `completed`
- **Full payment:** auto-advances to `paid` the moment the admin confirms payment (no separate settlement step).

## Changes

- [x] feat: add `paid` and `shipped` statuses between `verified` and `completed`, keeping `completed` for the final picked-up/received stage
- [x] feat: full-payment orders auto-advance to `paid` on payment verification; DP orders reach `paid` via settlement verification
- [x] feat: transition gates — `paid` requires a verified settlement (DP), `shipped` requires a tracking number (delivery orders)
- [x] feat: dashboard actions — "Mark Shipped / Ready for Pickup" and "Mark Completed" buttons, plus a tracking-number (resi) input modal
- [x] feat: shipping tracking number shown in the order detail modal
- [x] feat: adaptive status label — `shipped` renders as "Dikirim" for delivery and "Siap Diambil" for pickup
- [x] chore: align status filter, search aliases, Excel export labels, sold-stock counting, and revenue stat with the new statuses
- [x] chore: data migration — existing full-payment orders already in `verified` are bumped to `paid`

## Transition gates

| Transition | Guard |
|---|---|
| `verified → paid` (DP) | settlement must be verified |
| `paid → shipped` (delivery) | tracking number required |
| `paid → shipped` (pickup) | no extra requirement |
| `shipped → completed` | none (payment & shipping already enforced upstream) |

## Database

- `2026_06_01_140000_expand_order_status_flow` — widens the `status` ENUM to `pending, verified, paid, shipped, completed, cancelled` and migrates full-payment `verified` orders to `paid`.

## Testing

- Full payment: `pending → verified` correctly lands on `paid` (with invoice email) → `shipped` → `completed`.
- DP: `verified → paid` rejected without a verified settlement; settlement verification advances to `paid` (with paid email); `paid → shipped` rejected for delivery orders without a tracking number; succeeds after the resi is set; `shipped → completed` succeeds.
- Action buttons and adaptive labels render correctly per status (Mark Shipped vs Mark Ready for Pickup, etc.).
- PHP lint, `migrate`, Blade compilation, and asset build all pass. Test data was reset afterwards.

## Notes

- Running this migration **mutates existing data**: full-payment orders that were `verified` become `paid` to stay consistent with the new model.
- `public/build/` is gitignored — ensure assets are built in the deploy pipeline.
