### PR TITLE
Release v3.4.2

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -55,6 +55,11 @@ class AdminController extends Controller
         return $cards;
     }
 
+    private function stockCardsHtml(): string
+    {
+        return view('pages.admin._partials.stock-cards', ['stockCards' => $this->stockCards()])->render();
+    }
+
     private function orderStats(): array
     {
         $confirmed = ['verified', 'paid', 'shipped', 'completed'];
@@ -68,6 +73,7 @@ class AdminController extends Controller
             'completed' => Order::where('status', 'completed')->count(),
             'cancelled' => Order::where('status', 'cancelled')->count(),
             'confirmed' => Order::whereIn('status', $confirmed)->count(),
+            'settled' => Order::whereIn('status', ['paid', 'shipped', 'completed'])->count(),
             'revenue' => Order::whereIn('status', $confirmed)->sum('amount_due'),
         ];
     }
@@ -188,10 +194,10 @@ class AdminController extends Controller
         $statusLabels = [
             'pending' => 'Menunggu Pembayaran',
             'verified' => 'Pembayaran Diterima',
-            'paid' => 'Lunas',
-            'shipped' => 'Dikirim',
-            'completed' => 'Selesai',
-            'cancelled' => 'Dibatalkan',
+            'paid' => 'Pembayaran Lunas',
+            'shipped' => 'Pesanan Dikirim',
+            'completed' => 'Pesanan Selesai',
+            'cancelled' => 'Pesanan Dibatalkan',
         ];
         $paymentTypeLabels = ['dp' => 'DP (50%)', 'full' => 'Bayar Lunas'];
         $shippingLabels = ['kirim' => 'Dikirim', 'pickup' => 'Ambil di Tempat'];
@@ -336,14 +342,6 @@ class AdminController extends Controller
             $next = 'paid';
         }
 
-        // DP hanya bisa 'paid' jika pelunasannya sudah diverifikasi.
-        if ($next === 'paid' && $order->payment_type === 'dp' && empty($order->dp_settlement_verified_at)) {
-            return response()->json([
-                'ok' => false,
-                'message' => 'Verifikasi pelunasan DP terlebih dahulu.',
-            ], 422);
-        }
-
         // Pesanan kirim wajib punya nomor resi sebelum ditandai dikirim.
         if ($next === 'shipped' && $order->shipping_method === 'kirim' && empty($order->shipping_tracking)) {
             return response()->json([
@@ -353,6 +351,14 @@ class AdminController extends Controller
         }
 
         $prev = $order->status;
+
+        // Tandai lunas manual: DP yang dilunasi tanpa bukti dari pembeli (konfirmasi admin).
+        $manualSettlement = false;
+        if ($next === 'paid' && $order->payment_type === 'dp' && empty($order->dp_settlement_verified_at)) {
+            $order->dp_settlement_verified_at = now();
+            $order->dp_settlement_uploaded_at = $order->dp_settlement_uploaded_at ?? now();
+            $manualSettlement = true;
+        }
 
         $order->status = $next;
         if (in_array($next, ['verified', 'paid', 'shipped', 'completed'], true)) {
@@ -367,15 +373,16 @@ class AdminController extends Controller
         if ($next === 'verified' && $prev !== 'verified' && $order->payment_type === 'dp') {
             // DP diterima → ajakan pelunasan.
             $this->sendOrderMail($order, 'dp-verified');
-        } elseif ($next === 'paid' && $prev !== 'paid' && $order->payment_type === 'full') {
-            // Full payment diverifikasi → invoice pembayaran diterima.
-            $this->sendOrderMail($order, 'invoice');
+        } elseif ($next === 'paid' && $prev !== 'paid') {
+            // Lunas: full payment → invoice; DP (manual/terverifikasi) → konfirmasi lunas.
+            $this->sendOrderMail($order, $order->payment_type === 'full' ? 'invoice' : 'settlement-verified');
         }
 
         return response()->json([
             'ok' => true,
-            'message' => 'Status pesanan diperbarui.',
+            'message' => $manualSettlement ? 'Pesanan ditandai lunas.' : 'Status pesanan diperbarui.',
             'stats' => $this->orderStats(),
+            'stockHtml' => $this->stockCardsHtml(),
         ]);
     }
 
@@ -403,6 +410,7 @@ class AdminController extends Controller
             'ok' => true,
             'message' => 'Pesanan dibatalkan.',
             'stats' => $this->orderStats(),
+            'stockHtml' => $this->stockCardsHtml(),
         ]);
     }
 
@@ -466,6 +474,7 @@ class AdminController extends Controller
             'ok' => true,
             'message' => 'Bukti pelunasan tersimpan & terverifikasi.',
             'stats' => $this->orderStats(),
+            'stockHtml' => $this->stockCardsHtml(),
         ]);
     }
 
@@ -497,6 +506,7 @@ class AdminController extends Controller
             'ok' => true,
             'message' => 'Pelunasan DP terverifikasi.',
             'stats' => $this->orderStats(),
+            'stockHtml' => $this->stockCardsHtml(),
         ]);
     }
 
@@ -562,15 +572,15 @@ class AdminController extends Controller
 
     private function statusMeta(string $status, ?string $shippingMethod = null): array
     {
-        $shippedLabel = $shippingMethod === 'pickup' ? 'Siap Diambil' : 'Dikirim';
+        $shippedLabel = $shippingMethod === 'pickup' ? 'Pesanan Siap Diambil' : 'Pesanan Dikirim';
 
         return [
             'pending' => ['label' => 'Menunggu Pembayaran', 'class' => 'bg-amber-100 text-amber-700', 'icon' => 'ri-time-line'],
             'verified' => ['label' => 'Pembayaran Diterima', 'class' => 'bg-emerald-100 text-emerald-700', 'icon' => 'ri-shield-check-line'],
-            'paid' => ['label' => 'Lunas', 'class' => 'bg-teal-100 text-teal-700', 'icon' => 'ri-money-dollar-circle-line'],
+            'paid' => ['label' => 'Pembayaran Lunas', 'class' => 'bg-teal-100 text-teal-700', 'icon' => 'ri-money-dollar-circle-line'],
             'shipped' => ['label' => $shippedLabel, 'class' => 'bg-blue-100 text-blue-700', 'icon' => 'ri-truck-line'],
-            'completed' => ['label' => 'Selesai', 'class' => 'bg-sky-100 text-sky-700', 'icon' => 'ri-flag-line'],
-            'cancelled' => ['label' => 'Dibatalkan', 'class' => 'bg-red-100 text-red-700', 'icon' => 'ri-close-circle-line'],
+            'completed' => ['label' => 'Pesanan Selesai', 'class' => 'bg-sky-100 text-sky-700', 'icon' => 'ri-flag-line'],
+            'cancelled' => ['label' => 'Pesanan Dibatalkan', 'class' => 'bg-red-100 text-red-700', 'icon' => 'ri-close-circle-line'],
         ][$status] ?? ['label' => ucfirst($status), 'class' => 'bg-gray-100 text-gray-700', 'icon' => 'ri-question-line'];
     }
 
@@ -902,34 +912,43 @@ class AdminController extends Controller
                 .'</button>';
         }
 
+        // Verifikasi bukti pelunasan dari pembeli (self-service).
         if ($order->payment_type === 'dp' && $order->dp_settlement_proof && ! $order->dp_settlement_verified_at
-            && $order->status !== 'cancelled') {
-            $items .= '<button type="button" role="menuitem" data-action="settlement-verify" data-order="'.$orderId.'" class="dropdown-item dropdown-item--success">'
-                .'<i class="ri-shield-check-line"></i><span>Verifikasi Pelunasan</span>'
+            && $order->status === 'verified') {
+            $items .= '<button type="button" role="menuitem" data-action="settlement-verify" data-order="'.$orderId.'" class="dropdown-item dropdown-item--settle">'
+                .'<i class="ri-verified-badge-line"></i><span>Verifikasi Pelunasan</span>'
+                .'</button>';
+        }
+
+        // Tandai lunas manual (DP tanpa bukti dari pembeli).
+        if ($order->payment_type === 'dp' && ! $order->dp_settlement_proof && ! $order->dp_settlement_verified_at
+            && $order->status === 'verified') {
+            $items .= '<button type="button" role="menuitem" data-action="status" data-status="paid" data-order="'.$orderId.'" class="dropdown-item dropdown-item--settle">'
+                .'<i class="ri-money-dollar-circle-line"></i><span>Tandai Lunas</span>'
                 .'</button>';
         }
 
         if ($order->shipping_method === 'kirim' && in_array($order->status, ['paid', 'shipped'], true)) {
-            $items .= '<button type="button" role="menuitem" data-action="shipping" data-order="'.$orderId.'" data-tracking="'.e($order->shipping_tracking ?? '').'" class="dropdown-item dropdown-item--info">'
+            $items .= '<button type="button" role="menuitem" data-action="shipping" data-order="'.$orderId.'" data-tracking="'.e($order->shipping_tracking ?? '').'" class="dropdown-item dropdown-item--resi">'
                 .'<i class="ri-barcode-line"></i><span>'.($order->shipping_tracking ? 'Ubah Nomor Resi' : 'Input Nomor Resi').'</span>'
                 .'</button>';
         }
 
         if ($order->status === 'paid') {
             $shipLabel = $order->shipping_method === 'pickup' ? 'Tandai Siap Diambil' : 'Tandai Dikirim';
-            $items .= '<button type="button" role="menuitem" data-action="status" data-status="shipped" data-order="'.$orderId.'" class="dropdown-item dropdown-item--info">'
+            $items .= '<button type="button" role="menuitem" data-action="status" data-status="shipped" data-order="'.$orderId.'" class="dropdown-item dropdown-item--ship">'
                 .'<i class="ri-truck-line"></i><span>'.$shipLabel.'</span>'
                 .'</button>';
         }
 
         if ($order->status === 'shipped') {
-            $items .= '<button type="button" role="menuitem" data-action="status" data-status="completed" data-order="'.$orderId.'" class="dropdown-item dropdown-item--success">'
+            $items .= '<button type="button" role="menuitem" data-action="status" data-status="completed" data-order="'.$orderId.'" class="dropdown-item dropdown-item--complete">'
                 .'<i class="ri-flag-line"></i><span>Tandai Selesai</span>'
                 .'</button>';
         }
 
         if ($order->status !== 'cancelled' && $order->status !== 'completed') {
-            $items .= '<button type="button" role="menuitem" data-action="sync-payment" data-order="'.$orderId.'" data-subtotal="'.(int) $order->subtotal.'" data-amount-due="'.(int) $order->amount_due.'" class="dropdown-item dropdown-item--info">'
+            $items .= '<button type="button" role="menuitem" data-action="sync-payment" data-order="'.$orderId.'" data-subtotal="'.(int) $order->subtotal.'" data-amount-due="'.(int) $order->amount_due.'" class="dropdown-item dropdown-item--warning">'
                 .'<i class="ri-refresh-line"></i><span>Sinkronisasi Pembayaran</span>'
                 .'</button>';
         }

--- a/resources/assets/js/pages/admin-dashboard.js
+++ b/resources/assets/js/pages/admin-dashboard.js
@@ -316,6 +316,7 @@ document.addEventListener('DOMContentLoaded', () => {
             try { payload = await res.json(); } catch (_) {}
             if (!res.ok || !payload?.ok) throw new Error(payload?.message || 'Gagal memperbarui pembayaran.');
             applyStats(payload.stats);
+            applyStock(payload.stockHtml);
             toast?.fire({ icon: 'success', title: 'Pembayaran disinkronkan', text: `Pesanan ${syncState.orderId} diperbarui.` });
             dt.ajax.reload(null, false);
             const openOrder = detailModalContent?.querySelector('.detail-modal')?.dataset?.order;
@@ -449,6 +450,12 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     };
 
+    // Render ulang kartu "Stok Terjual" tanpa refresh halaman.
+    const stockRoot = document.querySelector('[data-stock-root]');
+    const applyStock = (html) => {
+        if (typeof html === 'string' && stockRoot) stockRoot.innerHTML = html;
+    };
+
     const handleStatus = async (btn) => {
         const orderId = btn.dataset.order;
         const status = btn.dataset.status;
@@ -459,6 +466,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 icon: 'question',
                 confirmText: 'Ya, diterima',
                 toast: 'Pembayaran berhasil diterima.',
+            },
+            paid: {
+                title: 'Tandai pesanan lunas?',
+                text: 'Sisa pembayaran DP dianggap sudah diterima (konfirmasi manual admin). Pesanan akan ditandai LUNAS.',
+                icon: 'question',
+                confirmText: 'Ya, lunas',
+                toast: 'Pesanan ditandai lunas.',
             },
             shipped: {
                 title: 'Tandai pesanan dikirim?',
@@ -499,6 +513,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 throw new Error(payload?.message || 'Terjadi kesalahan.');
             }
             applyStats(payload.stats);
+            applyStock(payload.stockHtml);
             toast?.fire({ icon: 'success', title: 'Status diperbarui', text: cfg.toast });
             dt.ajax.reload(null, false);
             await refreshOpenDetail(orderId);
@@ -527,6 +542,7 @@ document.addEventListener('DOMContentLoaded', () => {
             try { payload = await res.json(); } catch (_) {}
             if (!res.ok || !payload?.ok) throw new Error(payload?.message || 'Gagal memverifikasi pelunasan.');
             applyStats(payload.stats);
+            applyStock(payload.stockHtml);
             toast?.fire({ icon: 'success', title: 'Pelunasan terverifikasi', text: `Pesanan ${orderId} sudah lunas.` });
             dt.ajax.reload(null, false);
             const openOrder = detailModalContent?.querySelector('.detail-modal')?.dataset?.order;
@@ -565,6 +581,7 @@ document.addEventListener('DOMContentLoaded', () => {
             try { payload = await res.json(); } catch (_) {}
             if (!res.ok || !payload?.ok) throw new Error(payload?.message || 'Gagal membatalkan.');
             applyStats(payload.stats);
+            applyStock(payload.stockHtml);
             toast?.fire({ icon: 'success', title: 'Dibatalkan', text: `Pesanan ${orderId} dibatalkan.` });
             dt.ajax.reload(null, false);
             // If deleted order is the currently open one, close modal; else refresh detail to update duplicate list

--- a/resources/assets/plugins/datatables/datatables.css
+++ b/resources/assets/plugins/datatables/datatables.css
@@ -444,48 +444,42 @@ div.dt-container .dt-processing > div:last-child {
 }
 
 .orders-dropdown .dropdown-item {
-    @apply inline-flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[11.5px] font-medium text-foreground transition hover:bg-skull hover:text-foreground;
+    @apply inline-flex w-full cursor-pointer items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-[11.5px] font-semibold text-foreground transition hover:bg-skull hover:text-foreground;
 }
 
+/* Ikon dalam "chip" bulat berwarna agar aksi lebih menonjol & enak dipindai. */
 .orders-dropdown .dropdown-item > i {
-    @apply text-base text-onyx/70;
+    @apply flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-skull text-[14px] text-onyx transition;
 }
 
-.orders-dropdown .dropdown-item:hover > i {
-    @apply text-foreground;
+.orders-dropdown .dropdown-item:hover {
+    @apply translate-x-0.5;
 }
 
-.orders-dropdown .dropdown-item--success {
-    @apply text-emerald-700 hover:bg-emerald-50;
-}
-.orders-dropdown .dropdown-item--success > i,
-.orders-dropdown .dropdown-item--success:hover > i {
-    @apply text-emerald-600;
-}
+/* Color variant generator: tinted text + colored icon chip + tinted hover. */
+.orders-dropdown .dropdown-item--success { @apply text-emerald-700 hover:bg-emerald-50; }
+.orders-dropdown .dropdown-item--success > i { @apply bg-emerald-100 text-emerald-600; }
 
-.orders-dropdown .dropdown-item--info {
-    @apply text-blue-700 hover:bg-blue-50;
-}
-.orders-dropdown .dropdown-item--info > i,
-.orders-dropdown .dropdown-item--info:hover > i {
-    @apply text-blue-600;
-}
+.orders-dropdown .dropdown-item--settle { @apply text-teal-700 hover:bg-teal-50; }
+.orders-dropdown .dropdown-item--settle > i { @apply bg-teal-100 text-teal-600; }
 
-.orders-dropdown .dropdown-item--warning {
-    @apply text-amber-700 hover:bg-amber-50;
-}
-.orders-dropdown .dropdown-item--warning > i,
-.orders-dropdown .dropdown-item--warning:hover > i {
-    @apply text-amber-600;
-}
+.orders-dropdown .dropdown-item--resi { @apply text-indigo-700 hover:bg-indigo-50; }
+.orders-dropdown .dropdown-item--resi > i { @apply bg-indigo-100 text-indigo-600; }
 
-.orders-dropdown .dropdown-item--danger {
-    @apply text-red-700 hover:bg-red-50;
-}
-.orders-dropdown .dropdown-item--danger > i,
-.orders-dropdown .dropdown-item--danger:hover > i {
-    @apply text-red-600;
-}
+.orders-dropdown .dropdown-item--ship { @apply text-sky-700 hover:bg-sky-50; }
+.orders-dropdown .dropdown-item--ship > i { @apply bg-sky-100 text-sky-600; }
+
+.orders-dropdown .dropdown-item--complete { @apply text-violet-700 hover:bg-violet-50; }
+.orders-dropdown .dropdown-item--complete > i { @apply bg-violet-100 text-violet-600; }
+
+.orders-dropdown .dropdown-item--info { @apply text-blue-700 hover:bg-blue-50; }
+.orders-dropdown .dropdown-item--info > i { @apply bg-blue-100 text-blue-600; }
+
+.orders-dropdown .dropdown-item--warning { @apply text-amber-700 hover:bg-amber-50; }
+.orders-dropdown .dropdown-item--warning > i { @apply bg-amber-100 text-amber-600; }
+
+.orders-dropdown .dropdown-item--danger { @apply text-red-700 hover:bg-red-50; }
+.orders-dropdown .dropdown-item--danger > i { @apply bg-red-100 text-red-600; }
 
 /* ===== Stat card flash on update ===== */
 .stat-flash {

--- a/resources/views/pages/admin/_partials/stock-cards.blade.php
+++ b/resources/views/pages/admin/_partials/stock-cards.blade.php
@@ -1,0 +1,41 @@
+@foreach ($stockCards as $card)
+    @php
+        $tone = $card['remaining'] === null
+            ? ['bar' => 'bg-mercury', 'text' => 'text-foreground']
+            : ($card['remaining'] <= 0
+                ? ['bar' => 'bg-red-500', 'text' => 'text-red-600']
+                : ($card['limit'] > 0 && $card['remaining'] < ($card['limit'] * 0.2)
+                    ? ['bar' => 'bg-amber-500', 'text' => 'text-amber-600']
+                    : ['bar' => 'bg-emerald-500', 'text' => 'text-emerald-600']));
+    @endphp
+    <div class="flex flex-wrap items-center gap-4 rounded-xl border border-mercury bg-white p-4">
+        <div class="flex items-center gap-3">
+            <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <i class="ri-shirt-line text-xl"></i>
+            </div>
+            <div class="min-w-0">
+                <p class="text-[10px] font-semibold uppercase tracking-wider text-onyx">Stok Terjual</p>
+                <p class="truncate text-[13px] font-bold text-foreground">{{ $card['name'] }}</p>
+            </div>
+        </div>
+        <div class="min-w-0 flex-1">
+            @if ($card['limit'] > 0)
+                <div class="flex items-center justify-between gap-2">
+                    <p class="text-[13px] font-black {{ $tone['text'] }}">
+                        {{ number_format($card['sold']) }}
+                        <span class="text-[12px] font-bold text-onyx">/ {{ number_format($card['limit']) }}</span>
+                    </p>
+                    <p class="text-[11px] text-onyx">
+                        Sisa <span class="font-bold {{ $tone['text'] }}">{{ number_format($card['remaining']) }}</span> · {{ $card['progress'] }}%
+                    </p>
+                </div>
+                <div class="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-skull">
+                    <div class="h-full {{ $tone['bar'] }} transition-all" style="width: {{ $card['progress'] }}%"></div>
+                </div>
+            @else
+                <p class="text-[13px] font-black {{ $tone['text'] }}">{{ number_format($card['sold']) }}</p>
+                <p class="mt-0.5 text-[11px] text-onyx">Stok tidak diatur</p>
+            @endif
+        </div>
+    </div>
+@endforeach

--- a/resources/views/pages/admin/dashboard.blade.php
+++ b/resources/views/pages/admin/dashboard.blade.php
@@ -26,9 +26,28 @@
             <p class="text-[10px] font-semibold uppercase tracking-wider text-onyx">Menunggu Pembayaran</p>
             <p class="mt-1.5 text-xl font-black text-amber-600" data-stat="pending">{{ number_format($stats['pending']) }}</p>
         </div>
-        <div class="rounded-xl border border-mercury bg-white p-4">
-            <p class="text-[10px] font-semibold uppercase tracking-wider text-onyx">Pembayaran Diterima</p>
+        <div class="group relative rounded-xl border border-mercury bg-white p-4">
+            <div class="flex items-start justify-between gap-2">
+                <p class="text-[10px] font-semibold uppercase tracking-wider text-onyx">Pembayaran Diterima</p>
+                <button type="button" class="-mr-1 -mt-1 shrink-0 rounded-md p-1 text-onyx/50 transition hover:text-primary focus:text-primary focus:outline-none" aria-label="Rincian DP &amp; Lunas">
+                    <i class="ri-information-line text-sm"></i>
+                </button>
+            </div>
             <p class="mt-1.5 text-xl font-black text-emerald-600" data-stat="confirmed">{{ number_format($stats['confirmed']) }}</p>
+
+            <div class="invisible absolute right-3 top-12 z-20 w-48 origin-top-right -translate-y-1 scale-95 rounded-xl border border-mercury bg-white p-3 opacity-0 shadow-xl ring-1 ring-black/5 transition duration-150 group-hover:visible group-hover:translate-y-0 group-hover:scale-100 group-hover:opacity-100 group-focus-within:visible group-focus-within:translate-y-0 group-focus-within:scale-100 group-focus-within:opacity-100">
+                <p class="text-[10px] font-bold uppercase tracking-wider text-onyx">Rincian Pembayaran</p>
+                <div class="mt-2 space-y-2">
+                    <div class="flex items-center justify-between gap-2">
+                        <span class="inline-flex items-center gap-1.5 text-[11px] font-semibold text-amber-700"><i class="ri-hourglass-line"></i> DP (belum lunas)</span>
+                        <span class="text-[13px] font-black text-amber-700" data-stat="verified">{{ number_format($stats['verified']) }}</span>
+                    </div>
+                    <div class="flex items-center justify-between gap-2">
+                        <span class="inline-flex items-center gap-1.5 text-[11px] font-semibold text-teal-700"><i class="ri-checkbox-circle-line"></i> Lunas</span>
+                        <span class="text-[13px] font-black text-teal-700" data-stat="settled">{{ number_format($stats['settled']) }}</span>
+                    </div>
+                </div>
+            </div>
         </div>
         <div class="col-span-2 rounded-xl bg-linear-to-br from-primary via-primary-light to-primary-lighter p-4 text-white sm:col-span-3 lg:col-span-1">
             <p class="text-[10px] font-semibold uppercase tracking-wider text-white/80">Total Pendapatan</p>
@@ -36,51 +55,9 @@
         </div>
     </div>
 
-    @if (!empty($stockCards))
-        <div class="mt-3 flex flex-col gap-3">
-            @foreach ($stockCards as $card)
-                @php
-                    $tone = $card['remaining'] === null
-                        ? ['bar' => 'bg-mercury', 'text' => 'text-foreground']
-                        : ($card['remaining'] <= 0
-                            ? ['bar' => 'bg-red-500', 'text' => 'text-red-600']
-                            : ($card['limit'] > 0 && $card['remaining'] < ($card['limit'] * 0.2)
-                                ? ['bar' => 'bg-amber-500', 'text' => 'text-amber-600']
-                                : ['bar' => 'bg-emerald-500', 'text' => 'text-emerald-600']));
-                @endphp
-                <div class="flex flex-wrap items-center gap-4 rounded-xl border border-mercury bg-white p-4">
-                    <div class="flex items-center gap-3">
-                        <div class="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                            <i class="ri-shirt-line text-xl"></i>
-                        </div>
-                        <div class="min-w-0">
-                            <p class="text-[10px] font-semibold uppercase tracking-wider text-onyx">Stok Terjual</p>
-                            <p class="truncate text-[13px] font-bold text-foreground">{{ $card['name'] }}</p>
-                        </div>
-                    </div>
-                    <div class="min-w-0 flex-1">
-                        @if ($card['limit'] > 0)
-                            <div class="flex items-center justify-between gap-2">
-                                <p class="text-[13px] font-black {{ $tone['text'] }}">
-                                    {{ number_format($card['sold']) }}
-                                    <span class="text-[12px] font-bold text-onyx">/ {{ number_format($card['limit']) }}</span>
-                                </p>
-                                <p class="text-[11px] text-onyx">
-                                    Sisa <span class="font-bold {{ $tone['text'] }}">{{ number_format($card['remaining']) }}</span> · {{ $card['progress'] }}%
-                                </p>
-                            </div>
-                            <div class="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-skull">
-                                <div class="h-full {{ $tone['bar'] }} transition-all" style="width: {{ $card['progress'] }}%"></div>
-                            </div>
-                        @else
-                            <p class="text-[13px] font-black {{ $tone['text'] }}">{{ number_format($card['sold']) }}</p>
-                            <p class="mt-0.5 text-[11px] text-onyx">Stok tidak diatur</p>
-                        @endif
-                    </div>
-                </div>
-            @endforeach
-        </div>
-    @endif
+    <div class="mt-3 flex flex-col gap-3 empty:mt-0" data-stock-root>
+        @include('pages.admin._partials.stock-cards', ['stockCards' => $stockCards])
+    </div>
 
     <div class="mt-6">
         <div class="mb-3">
@@ -113,10 +90,10 @@
                         <option value="">Semua Status</option>
                         <option value="pending">Menunggu Pembayaran</option>
                         <option value="verified">Pembayaran Diterima</option>
-                        <option value="paid">Lunas</option>
-                        <option value="shipped">Dikirim</option>
-                        <option value="completed">Selesai</option>
-                        <option value="cancelled">Dibatalkan</option>
+                        <option value="paid">Pembayaran Lunas</option>
+                        <option value="shipped">Pesanan Dikirim</option>
+                        <option value="completed">Pesanan Selesai</option>
+                        <option value="cancelled">Pesanan Dibatalkan</option>
                     </select>
                 </div>
                 <div>


### PR DESCRIPTION
## Summary

Admin dashboard polish and workflow improvements on top of the new order status flow: a payment breakdown popover, a manual "mark as paid" action, a restyled action menu, clearer status badge labels, and live-refreshing sold-stock cards.

## Changes

- [x] feat: add an info popover on the "Pembayaran Diterima" stat card that breaks the count down into **DP (not yet settled)** vs **Lunas (fully paid)**, with live-updating numbers
- [x] feat: add a manual **"Tandai Lunas"** action (`verified → paid`) for DP orders that have no buyer-uploaded settlement proof — the admin confirms payment received offline; it records the settlement and sends the paid-confirmation email
- [x] feat: reload the **"Stok Terjual"** cards in place on every status change — no full page refresh needed
- [x] style: restyle the order action menu — a distinct color per action plus colored icon chips for faster scanning
- [x] refactor: rename status badges (badges, status filter, and Excel export) → **Pembayaran Lunas**, **Pesanan Dikirim** / **Pesanan Siap Diambil**, **Pesanan Selesai**, **Pesanan Dibatalkan**

## Details

- **Payment breakdown popover** — the "Pembayaran Diterima" card aggregates all confirmed payments; the popover splits it into `verified` (DP awaiting settlement) and `paid + shipped + completed` (fully paid). Both values are bound to new `verified` / `settled` stats and update via the existing live-stats mechanism. Shown on hover and keyboard focus (CSS only).
- **Manual "Tandai Lunas"** — appears only for DP orders at `verified` with no settlement proof (when a proof exists, the existing "Verifikasi Pelunasan" action is shown instead). It sets `dp_settlement_verified_at`, advances the order to `paid`, and emails the `settlement-verified` notice.
- **Live stock cards** — the stock cards were extracted into a Blade partial; the status / settlement-verify / cancel endpoints now return the rendered stock HTML, which the dashboard JS swaps into the `[data-stock-root]` container.
- **Action menu restyle** — each action gets its own hue: Confirm Payment (emerald), Verify/Mark Settlement (teal), Tracking Number (indigo), Mark Shipped (sky), Mark Completed (violet), Sync Payment (amber), Cancel (red).

## Testing

- Status badge, filter, and export labels render with the new names (incl. adaptive pickup label "Pesanan Siap Diambil").
- "Tandai Lunas" shows only when there is no settlement proof and is hidden once a proof exists; the transition reaches `paid`, records settlement, and sends the paid email.
- Status changes return `stockHtml` and the sold-stock cards update without a page refresh.
- PHP lint, asset build (CSS + JS), and Blade compilation pass. Test data was reset afterwards.

## Notes

- `public/build/` is gitignored — ensure assets are built in the deploy pipeline.
