### PR TITLE
Release v3.4.3

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -315,6 +315,7 @@ class AdminController extends Controller
     {
         $validated = $request->validate([
             'status' => ['required', 'in:pending,verified,paid,shipped,completed,cancelled'],
+            'tracking' => ['nullable', 'string', 'max:100'],
         ]);
 
         $next = $validated['status'];
@@ -343,11 +344,17 @@ class AdminController extends Controller
         }
 
         // Pesanan kirim wajib punya nomor resi sebelum ditandai dikirim.
-        if ($next === 'shipped' && $order->shipping_method === 'kirim' && empty($order->shipping_tracking)) {
-            return response()->json([
-                'ok' => false,
-                'message' => 'Input nomor resi terlebih dahulu sebelum menandai dikirim.',
-            ], 422);
+        // Resi bisa dikirim bersama aksi ini (alur gabungan "Tandai Dikirim").
+        if ($next === 'shipped' && $order->shipping_method === 'kirim') {
+            if (! empty($validated['tracking'])) {
+                $order->shipping_tracking = trim($validated['tracking']);
+            }
+            if (empty($order->shipping_tracking)) {
+                return response()->json([
+                    'ok' => false,
+                    'message' => 'Input nomor resi terlebih dahulu sebelum menandai dikirim.',
+                ], 422);
+            }
         }
 
         $prev = $order->status;
@@ -376,6 +383,9 @@ class AdminController extends Controller
         } elseif ($next === 'paid' && $prev !== 'paid') {
             // Lunas: full payment → invoice; DP (manual/terverifikasi) → konfirmasi lunas.
             $this->sendOrderMail($order, $order->payment_type === 'full' ? 'invoice' : 'settlement-verified');
+        } elseif ($next === 'shipped' && $prev !== 'shipped') {
+            // Dikirim (kurir) → kirim resi; pickup → info lokasi & kontak pengurus.
+            $this->sendOrderMail($order, $order->shipping_method === 'pickup' ? 'pickup-ready' : 'shipped');
         }
 
         return response()->json([
@@ -928,17 +938,24 @@ class AdminController extends Controller
                 .'</button>';
         }
 
-        if ($order->shipping_method === 'kirim' && in_array($order->status, ['paid', 'shipped'], true)) {
-            $items .= '<button type="button" role="menuitem" data-action="shipping" data-order="'.$orderId.'" data-tracking="'.e($order->shipping_tracking ?? '').'" class="dropdown-item dropdown-item--resi">'
-                .'<i class="ri-barcode-line"></i><span>'.($order->shipping_tracking ? 'Ubah Nomor Resi' : 'Input Nomor Resi').'</span>'
+        // Koreksi nomor resi setelah pesanan kirim ditandai dikirim.
+        if ($order->shipping_method === 'kirim' && $order->status === 'shipped') {
+            $items .= '<button type="button" role="menuitem" data-action="shipping" data-mode="edit" data-order="'.$orderId.'" data-tracking="'.e($order->shipping_tracking ?? '').'" class="dropdown-item dropdown-item--resi">'
+                .'<i class="ri-barcode-line"></i><span>Ubah Nomor Resi</span>'
                 .'</button>';
         }
 
         if ($order->status === 'paid') {
-            $shipLabel = $order->shipping_method === 'pickup' ? 'Tandai Siap Diambil' : 'Tandai Dikirim';
-            $items .= '<button type="button" role="menuitem" data-action="status" data-status="shipped" data-order="'.$orderId.'" class="dropdown-item dropdown-item--ship">'
-                .'<i class="ri-truck-line"></i><span>'.$shipLabel.'</span>'
-                .'</button>';
+            if ($order->shipping_method === 'pickup') {
+                $items .= '<button type="button" role="menuitem" data-action="status" data-status="shipped" data-order="'.$orderId.'" class="dropdown-item dropdown-item--ship">'
+                    .'<i class="ri-truck-line"></i><span>Tandai Siap Diambil</span>'
+                    .'</button>';
+            } else {
+                // Kirim: buka modal resi → simpan resi + tandai dikirim sekaligus.
+                $items .= '<button type="button" role="menuitem" data-action="shipping" data-mode="ship" data-order="'.$orderId.'" data-tracking="'.e($order->shipping_tracking ?? '').'" class="dropdown-item dropdown-item--ship">'
+                    .'<i class="ri-truck-line"></i><span>Tandai Dikirim</span>'
+                    .'</button>';
+            }
         }
 
         if ($order->status === 'shipped') {

--- a/app/Http/Controllers/CheckoutController.php
+++ b/app/Http/Controllers/CheckoutController.php
@@ -36,11 +36,12 @@ class CheckoutController extends Controller
 
     private function pickupLocations()
     {
-        return [
-            'purwokerto' => ['key' => 'purwokerto', 'name' => 'Purwokerto'],
-            'ajibarang' => ['key' => 'ajibarang', 'name' => 'Ajibarang'],
-            'jakarta' => ['key' => 'jakarta', 'name' => 'Jakarta'],
-        ];
+        $locations = [];
+        foreach (config('pickup.locations', []) as $key => $loc) {
+            $locations[$key] = ['key' => $key, 'name' => $loc['name']];
+        }
+
+        return $locations;
     }
 
     private function checkoutData()

--- a/app/Mail/OrderInvoice.php
+++ b/app/Mail/OrderInvoice.php
@@ -13,7 +13,7 @@ class OrderInvoice extends Mailable
     use Queueable, SerializesModels;
 
     /**
-     * @param  string  $mode  invoice | dp-verified | settlement-received | settlement-verified | reminder
+     * @param  string  $mode  invoice | dp-verified | settlement-received | settlement-verified | reminder | shipped | pickup-ready
      */
     public function __construct(public array $order, public string $mode = 'invoice') {}
 
@@ -24,6 +24,8 @@ class OrderInvoice extends Mailable
             'settlement-received' => 'Bukti Pelunasan Diterima — Pesanan '.$this->order['id'],
             'settlement-verified' => 'Pembayaran Lunas — Pesanan '.$this->order['id'],
             'reminder' => 'Pengingat Pelunasan — Pesanan '.$this->order['id'],
+            'shipped' => 'Pesanan Dikirim — Pesanan '.$this->order['id'],
+            'pickup-ready' => 'Pesanan Siap Diambil — Pesanan '.$this->order['id'],
             default => 'Invoice Pesanan '.$this->order['id'],
         };
 

--- a/app/Support/OrderPresenter.php
+++ b/app/Support/OrderPresenter.php
@@ -13,18 +13,16 @@ class OrderPresenter
         'kirim' => 'Kirim (Kurir)',
     ];
 
-    private const PICKUP_LABELS = [
-        'purwokerto' => 'Purwokerto',
-        'ajibarang' => 'Ajibarang',
-        'jakarta' => 'Jakarta',
-    ];
-
     /**
      * Susun array pesanan yang dikonsumsi template email (emails.order-invoice).
      * Dibangun mandiri dari model Order agar bisa dipakai di luar CheckoutController.
      */
     public static function mailData(Order $order): array
     {
+        $pickup = $order->pickup_location
+            ? config('pickup.locations.'.$order->pickup_location)
+            : null;
+
         return [
             'id' => $order->order_id,
             'customer' => [
@@ -37,10 +35,13 @@ class OrderPresenter
                 'key' => $order->shipping_method,
                 'name' => self::SHIPPING_LABELS[$order->shipping_method] ?? $order->shipping_method,
                 'address' => $order->customer_address,
+                'tracking' => $order->shipping_tracking,
                 'pickup_location' => $order->pickup_location,
-                'pickup_location_label' => $order->pickup_location
-                    ? (self::PICKUP_LABELS[$order->pickup_location] ?? ucfirst($order->pickup_location))
-                    : null,
+                'pickup_location_label' => $pickup['name']
+                    ?? ($order->pickup_location ? ucfirst($order->pickup_location) : null),
+                'pickup_address' => $pickup['address'] ?? null,
+                'pickup_contact_name' => $pickup['contact_name'] ?? null,
+                'pickup_contact_phone' => $pickup['contact_phone'] ?? null,
             ],
             'items' => $order->item ?? [],
             'subtotal' => (int) $order->subtotal,

--- a/config/pickup.php
+++ b/config/pickup.php
@@ -1,0 +1,37 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Titik Pengambilan (Pickup)
+    |--------------------------------------------------------------------------
+    |
+    | Detail tiap kota pengambilan. `name` dipakai untuk dropdown checkout,
+    | sedangkan `address` & `contact_*` ditampilkan pada email
+    | "Pesanan Siap Diambil" agar pembeli tahu lokasi & pengurus yang dituju.
+    |
+    | PENTING: ganti alamat & nomor kontak placeholder di bawah dengan data asli.
+    | Nomor kontak ditulis format internasional tanpa "+" (mis. 6281234567890).
+    |
+    */
+    'locations' => [
+        'purwokerto' => [
+            'name' => 'Purwokerto',
+            'address' => 'Jl. Jenderal Soedirman No.— , Purwokerto', // TODO: alamat asli
+            'contact_name' => 'Pengurus Purwokerto',                  // TODO: nama pengurus
+            'contact_phone' => '6282298001051',                       // TODO: nomor pengurus
+        ],
+        'ajibarang' => [
+            'name' => 'Ajibarang',
+            'address' => 'Jl. Raya Ajibarang No.— , Banyumas', // TODO: alamat asli
+            'contact_name' => 'Pengurus Ajibarang',            // TODO: nama pengurus
+            'contact_phone' => '6282298001051',                // TODO: nomor pengurus
+        ],
+        'jakarta' => [
+            'name' => 'Jakarta',
+            'address' => 'Jl. — No.— , Jakarta', // TODO: alamat asli
+            'contact_name' => 'Pengurus Jakarta', // TODO: nama pengurus
+            'contact_phone' => '6282298001051',   // TODO: nomor pengurus
+        ],
+    ],
+];

--- a/resources/assets/js/pages/admin-dashboard.js
+++ b/resources/assets/js/pages/admin-dashboard.js
@@ -343,14 +343,35 @@ document.addEventListener('DOMContentLoaded', () => {
     const shippingInput = shippingModal?.querySelector('[data-shipping-input]');
     const shippingError = shippingModal?.querySelector('[data-shipping-error]');
     const shippingSubmit = shippingModal?.querySelector('[data-shipping-submit]');
+    const shippingTitle = shippingModal?.querySelector('[data-shipping-title]');
+    const shippingSubtitle = shippingModal?.querySelector('[data-shipping-subtitle]');
     const shippingOrderIdEl = shippingModal?.querySelector('[data-shipping-order-id]');
-    const shippingState = { orderId: null };
+    const shippingState = { orderId: null, mode: 'edit' };
     let shippingLastTrigger = null;
 
-    const openShippingModal = (orderId, tracking, trigger) => {
+    // Tampilan modal menyesuaikan mode: "ship" = simpan resi + tandai dikirim sekaligus.
+    const shippingCopy = {
+        edit: {
+            title: 'Nomor Resi Pengiriman',
+            subtitle: 'Masukkan nomor resi JNT Express. Resi wajib diisi sebelum pesanan kirim bisa ditandai selesai.',
+            submit: '<i class="ri-save-3-line"></i> Simpan Resi',
+        },
+        ship: {
+            title: 'Tandai Dikirim',
+            subtitle: 'Masukkan nomor resi JNT Express. Pesanan akan langsung ditandai dikirim dan email berisi resi dikirim ke pembeli.',
+            submit: '<i class="ri-truck-line"></i> Kirim Pesanan',
+        },
+    };
+
+    const openShippingModal = (orderId, tracking, trigger, mode = 'edit') => {
         if (!shippingModal) return;
         shippingState.orderId = orderId;
+        shippingState.mode = shippingCopy[mode] ? mode : 'edit';
         shippingLastTrigger = trigger || null;
+        const copy = shippingCopy[shippingState.mode];
+        if (shippingTitle) shippingTitle.textContent = copy.title;
+        if (shippingSubtitle) shippingSubtitle.textContent = copy.subtitle;
+        if (shippingSubmit) shippingSubmit.innerHTML = copy.submit;
         if (shippingOrderIdEl) shippingOrderIdEl.textContent = orderId;
         if (shippingInput) shippingInput.value = tracking || '';
         if (shippingError) shippingError.classList.add('hidden');
@@ -375,28 +396,41 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const handleShipping = (btn) => {
-        if (!endpoints.shipping) return;
-        openShippingModal(btn.dataset.order, btn.dataset.tracking || '', btn);
+        const mode = btn.dataset.mode || 'edit';
+        // Mode "ship" butuh endpoint status; mode "edit" butuh endpoint shipping.
+        if (mode === 'ship' ? !endpoints.status : !endpoints.shipping) return;
+        openShippingModal(btn.dataset.order, btn.dataset.tracking || '', btn, mode);
     };
 
     shippingForm?.addEventListener('submit', async (e) => {
         e.preventDefault();
-        if (!shippingState.orderId || !endpoints.shipping) return;
+        if (!shippingState.orderId) return;
         const value = (shippingInput?.value || '').trim();
         if (!value) {
             if (shippingError) { shippingError.textContent = 'Nomor resi wajib diisi.'; shippingError.classList.remove('hidden'); }
             return;
         }
 
+        const isShip = shippingState.mode === 'ship';
+        const endpoint = isShip ? endpoints.status : endpoints.shipping;
+        if (!endpoint) return;
+
         if (shippingSubmit) shippingSubmit.disabled = true;
         try {
             const fd = new FormData();
             fd.append('tracking', value);
-            const res = await fetch(buildUrl(endpoints.shipping, shippingState.orderId), { method: 'POST', headers, body: fd });
+            if (isShip) fd.append('status', 'shipped');
+            const res = await fetch(buildUrl(endpoint, shippingState.orderId), { method: 'POST', headers, body: fd });
             let payload = null;
             try { payload = await res.json(); } catch (_) {}
-            if (!res.ok || !payload?.ok) throw new Error(payload?.message || 'Gagal menyimpan resi.');
-            toast?.fire({ icon: 'success', title: 'Resi tersimpan', text: `Pesanan ${shippingState.orderId} diperbarui.` });
+            if (!res.ok || !payload?.ok) throw new Error(payload?.message || (isShip ? 'Gagal menandai dikirim.' : 'Gagal menyimpan resi.'));
+            if (isShip) {
+                applyStats(payload.stats);
+                applyStock(payload.stockHtml);
+                toast?.fire({ icon: 'success', title: 'Pesanan dikirim', text: `Resi disimpan & ${shippingState.orderId} ditandai dikirim.` });
+            } else {
+                toast?.fire({ icon: 'success', title: 'Resi tersimpan', text: `Pesanan ${shippingState.orderId} diperbarui.` });
+            }
             dt.ajax.reload(null, false);
             await refreshOpenDetail(shippingState.orderId);
             closeShippingModal();
@@ -475,11 +509,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 toast: 'Pesanan ditandai lunas.',
             },
             shipped: {
-                title: 'Tandai pesanan dikirim?',
-                text: 'Pesanan akan ditandai dikirim / siap diambil. Untuk pesanan kirim, pastikan nomor resi sudah diisi.',
+                title: 'Tandai siap diambil?',
+                text: 'Pesanan akan ditandai siap diambil dan email berisi lokasi & kontak pengurus dikirim ke pembeli.',
                 icon: 'question',
-                confirmText: 'Ya, lanjut',
-                toast: 'Pesanan ditandai dikirim.',
+                confirmText: 'Ya, siap diambil',
+                toast: 'Pesanan ditandai siap diambil.',
             },
             completed: {
                 title: 'Tandai pesanan selesai?',

--- a/resources/views/emails/order-invoice.blade.php
+++ b/resources/views/emails/order-invoice.blade.php
@@ -19,6 +19,8 @@
         'settlement-received' => ['eyebrow' => 'BUKTI PELUNASAN DITERIMA', 'intro' => 'Kami sudah menerima bukti pelunasanmu. Tim kami akan segera memverifikasi pembayaran ini.'],
         'settlement-verified' => ['eyebrow' => 'PEMBAYARAN LUNAS', 'intro' => 'Pelunasan kamu sudah kami verifikasi. Pesananmu kini berstatus LUNAS dan akan segera kami proses. Terima kasih!'],
         'reminder' => ['eyebrow' => 'PENGINGAT PELUNASAN', 'intro' => $reminderIntro],
+        'shipped' => ['eyebrow' => 'PESANAN DIKIRIM', 'intro' => 'Kabar baik! Pesananmu sudah kami serahkan ke kurir dan sedang dalam perjalanan. Berikut nomor resi untuk melacak pengiriman:'],
+        'pickup-ready' => ['eyebrow' => 'PESANAN SIAP DIAMBIL', 'intro' => 'Pesananmu sudah siap diambil. Silakan datang ke titik pengambilan berikut dan hubungi pengurus kami terlebih dahulu:'],
     ];
     $head = $headings[$mode] ?? $headings['invoice'];
 @endphp
@@ -123,6 +125,56 @@
                                         <td style="padding:16px;background:#ecfdf5;border:1px solid #a7f3d0;border-radius:8px;">
                                             <div style="font-size:14px;font-weight:bold;color:#047857;">✓ Pembayaran Lunas</div>
                                             <div style="font-size:12px;color:#047857;line-height:1.6;margin-top:4px;">Total <strong>{{ $rupiah($order['subtotal']) }}</strong> telah kami terima penuh. Pesananmu akan segera diproses{{ ($shipping['key'] ?? null) === 'kirim' ? ' dan dikirim' : '' }}.</div>
+                                        </td>
+                                    </tr>
+                                </table>
+                                @elseif ($mode === 'shipped')
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:20px;">
+                                    <tr>
+                                        <td style="padding:16px;background:#eff6ff;border:1px solid #bfdbfe;border-radius:8px;">
+                                            <div style="font-size:13px;font-weight:bold;color:#1d4ed8;">Nomor Resi Pengiriman</div>
+                                            <div style="font-size:20px;font-weight:bold;color:#1e3a8a;letter-spacing:1px;margin-top:6px;font-family:'Courier New',monospace;">{{ $shipping['tracking'] ?? '-' }}</div>
+                                            <div style="font-size:12px;color:#1e40af;line-height:1.6;margin-top:8px;">Kurir: <strong>JNT Express</strong>. Gunakan nomor resi di atas untuk melacak status pengiriman pesananmu.</div>
+                                            @if (! empty($shipping['address']))
+                                            <div style="font-size:12px;color:#1e40af;line-height:1.6;margin-top:8px;">Dikirim ke:<br><span style="white-space:pre-line;">{{ $shipping['address'] }}</span></div>
+                                            @endif
+                                        </td>
+                                    </tr>
+                                </table>
+                                @elseif ($mode === 'pickup-ready')
+                                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:20px;">
+                                    <tr>
+                                        <td style="padding:16px;background:#ecfdf5;border:1px solid #a7f3d0;border-radius:8px;">
+                                            <div style="font-size:14px;font-weight:bold;color:#047857;">Pesanan Siap Diambil</div>
+                                            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="font-size:13px;color:#065f46;margin-top:10px;">
+                                                @if (! empty($shipping['pickup_location_label']))
+                                                <tr>
+                                                    <td style="padding:3px 0;color:#047857;width:130px;vertical-align:top;">Lokasi</td>
+                                                    <td style="padding:3px 0;font-weight:bold;">{{ $shipping['pickup_location_label'] }}</td>
+                                                </tr>
+                                                @endif
+                                                @if (! empty($shipping['pickup_address']))
+                                                <tr>
+                                                    <td style="padding:3px 0;color:#047857;vertical-align:top;">Alamat</td>
+                                                    <td style="padding:3px 0;white-space:pre-line;">{{ $shipping['pickup_address'] }}</td>
+                                                </tr>
+                                                @endif
+                                                @if (! empty($shipping['pickup_contact_name']))
+                                                <tr>
+                                                    <td style="padding:3px 0;color:#047857;vertical-align:top;">Pengurus</td>
+                                                    <td style="padding:3px 0;">{{ $shipping['pickup_contact_name'] }}</td>
+                                                </tr>
+                                                @endif
+                                                @if (! empty($shipping['pickup_contact_phone']))
+                                                <tr>
+                                                    <td style="padding:3px 0;color:#047857;vertical-align:top;">Kontak</td>
+                                                    <td style="padding:3px 0;font-weight:bold;">
+                                                        <a href="https://wa.me/{{ $shipping['pickup_contact_phone'] }}" style="color:#047857;text-decoration:underline;">+{{ $shipping['pickup_contact_phone'] }}</a>
+                                                    </td>
+                                                </tr>
+                                                @endif
+                                            </table>
+                                            <div style="font-size:12px;color:#047857;line-height:1.6;margin-top:10px;">Mohon hubungi pengurus terlebih dahulu sebelum datang untuk memastikan pesananmu siap diserahkan.</div>
                                         </td>
                                     </tr>
                                 </table>

--- a/resources/views/pages/admin/dashboard.blade.php
+++ b/resources/views/pages/admin/dashboard.blade.php
@@ -237,8 +237,8 @@
                     <div class="detail-hero__bg"></div>
                     <div class="relative flex flex-col gap-2 pr-12">
                         <span class="detail-chip detail-chip--glass w-fit font-mono"><i class="ri-truck-line"></i> <span data-shipping-order-id>—</span></span>
-                        <h2 id="shipping-modal-title" class="text-base font-black leading-tight text-white">Nomor Resi Pengiriman</h2>
-                        <p class="text-[12px] leading-relaxed text-white/85">Masukkan nomor resi JNT Express. Resi wajib diisi sebelum pesanan kirim bisa ditandai selesai.</p>
+                        <h2 id="shipping-modal-title" data-shipping-title class="text-base font-black leading-tight text-white">Nomor Resi Pengiriman</h2>
+                        <p data-shipping-subtitle class="text-[12px] leading-relaxed text-white/85">Masukkan nomor resi JNT Express. Resi wajib diisi sebelum pesanan kirim bisa ditandai selesai.</p>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary
This PR streamlines the "mark as shipped" action and adds transactional emails for the shipping stage of an order.

Previously, admins had to use **two separate menu actions** for courier orders — first "Input Nomor Resi" to save the tracking number, then "Tandai Dikirim" to change the status (which would fail if no resi was entered yet). This was confusing. Now it's a **single guided flow**, and customers are notified by email once their order ships or is ready for pickup.

## Changes

**1. Unified "Mark as Shipped" flow (single step)**
- For **courier** orders, the menu now shows only **"Tandai Dikirim"**, which opens the tracking-number modal. Submitting saves the resi **and** transitions the order to `shipped` in one atomic request.
- `updateStatus()` now accepts an optional `tracking` param and persists it before the required-resi validation.
- The standalone "Input Nomor Resi" action is removed. The resi modal now has two modes: `ship` (save resi + mark shipped) and `edit`. "Ubah Nomor Resi" remains available while an order is `shipped`, for corrections.
- For **pickup** orders, "Tandai Siap Diambil" stays a direct status action (no resi needed).

**2. New shipping-stage email notifications**
Triggered automatically when an order transitions to `shipped`:
- **Pesanan Dikirim** (courier) — shows the tracking number (resi), courier (JNT Express), and the destination address.
- **Pesanan Siap Diambil** (pickup) — shows the pickup location, address, contact person, and WhatsApp contact for the relevant city.

**3. Centralized pickup location config**
- Pickup details (name, address, contact name, contact phone) are now sourced from a single `config/pickup.php`, consumed by the checkout dropdown, the email presenter, and the dashboard. Removes the previously duplicated label maps.

## Files
- `app/Http/Controllers/AdminController.php` — combined shipping flow, shipped/pickup-ready email triggers
- `app/Http/Controllers/CheckoutController.php` — pickup locations read from config
- `app/Support/OrderPresenter.php` — adds tracking + pickup contact data to mail payload
- `app/Mail/OrderInvoice.php` — `shipped` & `pickup-ready` subjects
- `resources/views/emails/order-invoice.blade.php` — info boxes for the new modes
- `resources/views/pages/admin/dashboard.blade.php` + `resources/assets/js/pages/admin-dashboard.js` — dual-mode resi modal
- `config/pickup.php` — new centralized pickup config

## ⚠️ Action required before deploy
`config/pickup.php` ships with **placeholder** addresses and phone numbers (marked `// TODO`). Replace them with the real address and contact (format `62...`) for each city (Purwokerto, Ajibarang, Jakarta). Run `php artisan config:clear` if config is cached.

## Testing
- `php -l` passes on all changed PHP files
- `node --check` passes on the modified JS
- `npm run build` succeeds
- Manual: courier order → "Tandai Dikirim" → modal → save → status `shipped` + "Pesanan Dikirim" email with resi; pickup order → "Tandai Siap Diambil" → "Pesanan Siap Diambil" email with location & contact
