### PR TITLE
Release v3.4.5

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -492,6 +492,58 @@ class AdminController extends Controller
         ]);
     }
 
+    public function uploadPaymentProof(Request $request, Order $order)
+    {
+        $validated = $request->validate([
+            'proof' => ['required', 'file', 'mimes:jpg,jpeg,png,webp,pdf', 'max:5120'],
+            'type' => ['nullable', 'in:payment,settlement'],
+        ]);
+
+        $type = $validated['type'] ?? 'payment';
+
+        // Bukti pelunasan hanya berlaku untuk pesanan DP.
+        if ($type === 'settlement') {
+            if ($order->payment_type !== 'dp') {
+                return response()->json(['ok' => false, 'message' => 'Pesanan bukan tipe DP.'], 422);
+            }
+
+            $replacing = (bool) $order->dp_settlement_proof;
+            if ($replacing) {
+                Storage::disk('public')->delete($order->dp_settlement_proof);
+            }
+
+            $path = $request->file('proof')->store('proofs/settlements', 'public');
+            $order->update([
+                'dp_settlement_proof' => $path,
+                'dp_settlement_uploaded_at' => $order->dp_settlement_uploaded_at ?? now(),
+            ]);
+
+            return response()->json([
+                'ok' => true,
+                'message' => $replacing ? 'Bukti pelunasan berhasil diganti.' : 'Bukti pelunasan berhasil ditambahkan.',
+                'stats' => $this->orderStats(),
+            ]);
+        }
+
+        // Bukti transfer awal / pembayaran.
+        $replacing = (bool) $order->payment_proof;
+        if ($replacing) {
+            Storage::disk('public')->delete($order->payment_proof);
+        }
+
+        $path = $request->file('proof')->store('proofs', 'public');
+        $order->update([
+            'payment_proof' => $path,
+            'payment_proof_uploaded_at' => now(),
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            'message' => $replacing ? 'Bukti transfer berhasil diganti.' : 'Bukti transfer berhasil ditambahkan.',
+            'stats' => $this->orderStats(),
+        ]);
+    }
+
     public function uploadDpProof(Request $request, Order $order)
     {
         if ($order->payment_type !== 'dp') {
@@ -746,23 +798,8 @@ class AdminController extends Controller
                 .'</div>';
         }
 
-        // Proof chips
-        $proofs = [];
-        if ($order->payment_proof) {
-            $uploadedAt = $order->payment_proof_uploaded_at;
-            $uploadedLabel = $uploadedAt
-                ? $uploadedAt->locale('id')->translatedFormat('d M Y · H:i').' WIB'
-                : null;
-            $proofs[] = '<a href="'.e(asset('storage/'.$order->payment_proof)).'" target="_blank" class="detail-chip detail-chip--primary"><i class="ri-image-line"></i> Bukti Pembayaran <i class="ri-external-link-line text-[10px]"></i></a>'
-                .($uploadedLabel ? '<span class="inline-flex items-center gap-1 text-[11px] text-onyx"><i class="ri-time-line text-[12px]"></i> '.e($uploadedLabel).'</span>' : '');
-        }
-        if ($order->payment_type === 'dp' && $order->dp_settlement_proof) {
-            $proofs[] = '<a href="'.e(asset('storage/'.$order->dp_settlement_proof)).'" target="_blank" class="detail-chip detail-chip--success"><i class="ri-checkbox-circle-line"></i> Bukti Pelunasan DP <i class="ri-external-link-line text-[10px]"></i></a>';
-        }
-        if (empty($proofs)) {
-            $proofs[] = '<span class="detail-chip detail-chip--muted"><i class="ri-image-add-line"></i> Belum ada bukti</span>';
-        }
-        $proofHtml = implode('', $proofs);
+        // Bukti transfer: baris per-slot (lihat + tambah/ganti).
+        $proofRows = $this->renderProofRows($order);
 
         // Field row helper
         $field = fn ($label, $value, $icon = null) => '<div class="flex gap-3">'
@@ -885,7 +922,7 @@ class AdminController extends Controller
             .'</div>'
             .'</div>'
             .($order->payment_type === 'dp' ? $this->renderSettlementBlock($order, $rupiah) : '')
-            .'<div class="mt-3 flex flex-wrap items-center gap-2">'.$proofHtml.'</div>'
+            .$proofRows
             .'</div>'
 
             .'</div>';
@@ -919,6 +956,72 @@ class AdminController extends Controller
             .'<div class="detail-card__title text-amber-800"><i class="ri-error-warning-line"></i> Kemungkinan Pesanan Duplikat ('.$dupes->count().')</div>'
             .'<div class="text-[12px] text-amber-800/80">Pelanggan ini punya pesanan lain yang masih menunggu pembayaran tanpa bukti. Batalkan yang tidak terpakai.</div>'
             .'<div class="mt-2 flex flex-col gap-2">'.$itemsHtml.'</div>'
+            .'</div>';
+    }
+
+    /**
+     * Daftar bukti transfer (per-slot) di modal detail: lihat + tambah/ganti.
+     * Pesanan DP memiliki 2 slot: bukti transfer awal & bukti pelunasan.
+     */
+    private function renderProofRows(Order $order): string
+    {
+        $row = function (string $type, string $label, ?string $path, $uploadedAt) use ($order): string {
+            $has = (bool) $path;
+
+            $uploadedLabel = $uploadedAt
+                ? 'Diunggah '.$uploadedAt->locale('id')->translatedFormat('d M Y · H:i').' WIB'
+                : 'Sudah diunggah';
+
+            // Ikon + status kiri.
+            if ($has) {
+                $iconWrap = 'bg-emerald-50 text-emerald-600 ring-1 ring-emerald-200';
+                $icon = 'ri-image-2-line';
+                $statusHtml = '<div class="mt-0.5 inline-flex items-center gap-1 text-[11px] text-onyx"><i class="ri-checkbox-circle-fill text-[12px] text-emerald-500"></i> '.e($uploadedLabel).'</div>';
+            } else {
+                $iconWrap = 'bg-amber-50 text-amber-600 ring-1 ring-amber-200';
+                $icon = 'ri-image-add-line';
+                $statusHtml = '<div class="mt-0.5 inline-flex items-center gap-1 text-[11px] font-semibold text-amber-600"><i class="ri-error-warning-line text-[12px]"></i> Belum ada bukti</div>';
+            }
+
+            // Tombol kanan.
+            $viewBtn = $has
+                ? '<a href="'.e(asset('storage/'.$path)).'" target="_blank" rel="noopener" class="inline-flex h-8 items-center gap-1 rounded-lg border border-mercury bg-white px-2.5 text-[11px] font-bold text-foreground transition hover:border-primary hover:text-primary"><i class="ri-eye-line text-[13px]"></i> Lihat</a>'
+                : '';
+            $actionBtn = $has
+                ? '<button type="button" data-action="payment-proof" data-type="'.$type.'" data-order="'.e($order->order_id).'" data-has-proof="1" class="inline-flex h-8 items-center gap-1 rounded-lg border border-primary-soft bg-primary-softer px-2.5 text-[11px] font-bold text-primary transition hover:bg-primary-soft"><i class="ri-image-edit-line text-[13px]"></i> Ganti</button>'
+                : '<button type="button" data-action="payment-proof" data-type="'.$type.'" data-order="'.e($order->order_id).'" data-has-proof="0" class="inline-flex h-8 items-center gap-1 rounded-lg bg-primary px-2.5 text-[11px] font-bold text-white shadow-sm transition hover:bg-primary-light"><i class="ri-upload-2-line text-[13px]"></i> Tambah</button>';
+
+            return '<div class="flex items-center justify-between gap-3 rounded-xl border border-mercury bg-skull/40 px-3 py-2.5">'
+                .'<div class="flex min-w-0 items-center gap-2.5">'
+                .'<div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg '.$iconWrap.'"><i class="'.$icon.' text-base"></i></div>'
+                .'<div class="min-w-0">'
+                .'<div class="truncate text-[12px] font-bold text-foreground">'.e($label).'</div>'
+                .$statusHtml
+                .'</div>'
+                .'</div>'
+                .'<div class="flex shrink-0 items-center gap-1.5">'.$viewBtn.$actionBtn.'</div>'
+                .'</div>';
+        };
+
+        $rows = $row(
+            'payment',
+            $order->payment_type === 'dp' ? 'Bukti Transfer DP' : 'Bukti Transfer',
+            $order->payment_proof,
+            $order->payment_proof_uploaded_at,
+        );
+
+        if ($order->payment_type === 'dp') {
+            $rows .= $row(
+                'settlement',
+                'Bukti Pelunasan DP',
+                $order->dp_settlement_proof,
+                $order->dp_settlement_uploaded_at,
+            );
+        }
+
+        return '<div class="mt-3">'
+            .'<div class="mb-2 text-[10px] font-bold uppercase tracking-wider text-onyx">Bukti Transfer</div>'
+            .'<div class="flex flex-col gap-2">'.$rows.'</div>'
             .'</div>';
     }
 

--- a/resources/assets/js/pages/admin-dashboard.js
+++ b/resources/assets/js/pages/admin-dashboard.js
@@ -16,6 +16,7 @@ document.addEventListener('DOMContentLoaded', () => {
         settlementVerify: root?.dataset.settlementVerifyUrl,
         shipping: root?.dataset.shippingUrl,
         pickup: root?.dataset.pickupUrl,
+        paymentProof: root?.dataset.paymentProofUrl,
         delete: root?.dataset.deleteUrl,
     };
 
@@ -187,7 +188,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const btn = e.target.closest('button[data-action]');
         if (!btn) return;
         e.preventDefault();
-        const map = { detail: handleDetail, status: handleStatus, delete: handleDelete, 'sync-payment': handleSyncPayment, 'settlement-verify': handleSettlementVerify, shipping: handleShipping, pickup: handlePickup };
+        const map = { detail: handleDetail, status: handleStatus, delete: handleDelete, 'sync-payment': handleSyncPayment, 'settlement-verify': handleSettlementVerify, shipping: handleShipping, pickup: handlePickup, 'payment-proof': handlePaymentProof };
         map[btn.dataset.action]?.(btn);
     });
 
@@ -555,6 +556,111 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    // ===== Bukti Transfer (Payment Proof) Modal =====
+    const proofModal = document.getElementById('payment-proof-modal');
+    const proofForm = proofModal?.querySelector('[data-proof-form]');
+    const proofInput = proofModal?.querySelector('[data-proof-input]');
+    const proofFilename = proofModal?.querySelector('[data-proof-filename]');
+    const proofError = proofModal?.querySelector('[data-proof-error]');
+    const proofSubmit = proofModal?.querySelector('[data-proof-submit]');
+    const proofTitle = proofModal?.querySelector('[data-proof-title]');
+    const proofSubtitle = proofModal?.querySelector('[data-proof-subtitle]');
+    const proofOrderIdEl = proofModal?.querySelector('[data-proof-order-id]');
+    const proofState = { orderId: null, type: 'payment' };
+    let proofLastTrigger = null;
+
+    const proofCopy = {
+        payment: {
+            title: 'Bukti Transfer',
+            add: 'Unggah bukti transfer pembayaran untuk pesanan ini.',
+            replace: 'Unggah file baru untuk mengganti bukti transfer lama. File lama akan dihapus.',
+        },
+        settlement: {
+            title: 'Bukti Pelunasan DP',
+            add: 'Unggah bukti transfer pelunasan sisa DP untuk pesanan ini.',
+            replace: 'Unggah file baru untuk mengganti bukti pelunasan lama. File lama akan dihapus.',
+        },
+    };
+
+    const resetProofField = () => {
+        if (proofInput) proofInput.value = '';
+        if (proofFilename) proofFilename.textContent = 'Klik untuk pilih file';
+        if (proofError) proofError.classList.add('hidden');
+    };
+
+    const openProofModal = (btn) => {
+        if (!proofModal) return;
+        proofState.orderId = btn.dataset.order;
+        proofState.type = proofCopy[btn.dataset.type] ? btn.dataset.type : 'payment';
+        proofLastTrigger = btn || null;
+        const replacing = btn.dataset.hasProof === '1';
+        const copy = proofCopy[proofState.type];
+        if (proofTitle) proofTitle.textContent = (replacing ? 'Ganti ' : 'Tambah ') + copy.title;
+        if (proofSubtitle) proofSubtitle.textContent = replacing ? copy.replace : copy.add;
+        if (proofOrderIdEl) proofOrderIdEl.textContent = btn.dataset.order;
+        if (proofSubmit) proofSubmit.disabled = false;
+        resetProofField();
+        proofModal.hidden = false;
+        proofModal.removeAttribute('aria-hidden');
+        document.body.style.overflow = 'hidden';
+    };
+
+    const closeProofModal = () => {
+        if (!proofModal || proofModal.hidden) return;
+        proofModal.hidden = true;
+        proofModal.setAttribute('aria-hidden', 'true');
+        if (!detailModal || detailModal.hidden) document.body.style.overflow = '';
+        resetProofField();
+        proofLastTrigger?.focus({ preventScroll: true });
+        proofLastTrigger = null;
+    };
+
+    proofModal?.querySelectorAll('[data-proof-close]').forEach((el) => {
+        el.addEventListener('click', closeProofModal);
+    });
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && proofModal && !proofModal.hidden) closeProofModal();
+    });
+
+    proofInput?.addEventListener('change', () => {
+        const file = proofInput.files?.[0];
+        if (proofFilename) proofFilename.textContent = file ? file.name : 'Klik untuk pilih file';
+        if (file && proofError) proofError.classList.add('hidden');
+    });
+
+    const handlePaymentProof = (btn) => {
+        if (!endpoints.paymentProof) return;
+        openProofModal(btn);
+    };
+
+    proofForm?.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        if (!proofState.orderId || !endpoints.paymentProof) return;
+        const file = proofInput?.files?.[0];
+        const showErr = (msg) => { if (proofError) { proofError.textContent = msg; proofError.classList.remove('hidden'); } };
+        if (!file) return showErr('Pilih file bukti transfer terlebih dahulu.');
+        if (file.size > 5 * 1024 * 1024) return showErr('Ukuran file maksimal 5 MB.');
+
+        if (proofSubmit) proofSubmit.disabled = true;
+        try {
+            const fd = new FormData();
+            fd.append('proof', file);
+            fd.append('type', proofState.type);
+            const res = await fetch(buildUrl(endpoints.paymentProof, proofState.orderId), { method: 'POST', headers, body: fd });
+            let payload = null;
+            try { payload = await res.json(); } catch (_) {}
+            if (!res.ok || !payload?.ok) throw new Error(payload?.message || 'Gagal mengunggah bukti transfer.');
+            applyStats(payload.stats);
+            toast?.fire({ icon: 'success', title: 'Bukti tersimpan', text: payload.message || `Bukti transfer ${proofState.orderId} diperbarui.` });
+            dt.ajax.reload(null, false);
+            await refreshOpenDetail(proofState.orderId);
+            closeProofModal();
+        } catch (err) {
+            showErr(err.message);
+            if (proofSubmit) proofSubmit.disabled = false;
+        }
+    });
+
     const handleDetail = async (btn) => {
         const orderId = btn.dataset.order;
         lastTrigger = btn;
@@ -783,7 +889,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const btn = e.target.closest('button[data-action]');
         if (!btn) return;
         closeDropdowns();
-        const map = { detail: handleDetail, status: handleStatus, delete: handleDelete, 'sync-payment': handleSyncPayment, 'settlement-verify': handleSettlementVerify, shipping: handleShipping, pickup: handlePickup };
+        const map = { detail: handleDetail, status: handleStatus, delete: handleDelete, 'sync-payment': handleSyncPayment, 'settlement-verify': handleSettlementVerify, shipping: handleShipping, pickup: handlePickup, 'payment-proof': handlePaymentProof };
         map[btn.dataset.action]?.(btn);
     });
 

--- a/resources/views/pages/admin/dashboard.blade.php
+++ b/resources/views/pages/admin/dashboard.blade.php
@@ -75,6 +75,7 @@
             data-settlement-verify-url="{{ url('admin/orders/__ORDER__/settlement-verify') }}"
             data-shipping-url="{{ url('admin/orders/__ORDER__/shipping') }}"
             data-pickup-url="{{ url('admin/orders/__ORDER__/pickup') }}"
+            data-payment-proof-url="{{ url('admin/orders/__ORDER__/payment-proof') }}"
             data-delete-url="{{ url('admin/orders/__ORDER__') }}">
             <div class="orders-filters grid grid-cols-1 gap-3 border-b border-mercury bg-skull/40 p-4 sm:grid-cols-2 lg:grid-cols-4">
                 <div>
@@ -312,6 +313,45 @@
                         <button type="button" data-pickup-close class="inline-flex h-10 items-center justify-center gap-1.5 rounded-lg border border-mercury bg-white px-4 text-[13px] font-semibold text-foreground transition hover:bg-skull">Batal</button>
                         <button type="submit" data-pickup-submit class="inline-flex h-10 items-center justify-center gap-1.5 rounded-lg bg-primary px-4 text-[13px] font-bold text-white shadow-sm transition hover:bg-primary-light disabled:cursor-not-allowed disabled:opacity-60">
                             <i class="ri-save-3-line"></i> Simpan
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div id="payment-proof-modal" class="order-modal" hidden aria-hidden="true">
+        <div class="order-modal__backdrop" data-proof-close></div>
+        <div class="order-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="payment-proof-modal-title">
+            <button type="button" class="order-modal__close" data-proof-close aria-label="Tutup">
+                <i class="ri-close-line"></i>
+            </button>
+            <div class="order-modal__body">
+                <div class="detail-hero">
+                    <div class="detail-hero__bg"></div>
+                    <div class="relative flex flex-col gap-2 pr-12">
+                        <span class="detail-chip detail-chip--glass w-fit font-mono"><i class="ri-receipt-line"></i> <span data-proof-order-id>—</span></span>
+                        <h2 id="payment-proof-modal-title" data-proof-title class="text-base font-black leading-tight text-white">Bukti Transfer</h2>
+                        <p data-proof-subtitle class="text-[12px] leading-relaxed text-white/85">Unggah bukti transfer pembayaran untuk pesanan ini.</p>
+                    </div>
+                </div>
+
+                <form data-proof-form class="flex flex-col gap-4 px-5 py-5">
+                    <div>
+                        <label class="mb-1.5 block text-[11px] font-bold uppercase tracking-wider text-onyx">File Bukti Transfer</label>
+                        <label class="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border-2 border-dashed border-mercury bg-skull/40 px-4 py-6 text-center transition hover:border-primary hover:bg-primary-softer">
+                            <i class="ri-upload-cloud-2-line text-2xl text-onyx"></i>
+                            <span data-proof-filename class="text-[12px] font-semibold text-onyx">Klik untuk pilih file</span>
+                            <span class="text-[10px] text-onyx/70">JPG · PNG · WEBP · PDF — maks. 5 MB</span>
+                            <input type="file" accept=".jpg,.jpeg,.png,.webp,.pdf,image/*,application/pdf" data-proof-input class="hidden" />
+                        </label>
+                        <p class="mt-1.5 hidden text-[11px] font-semibold text-red-600" data-proof-error></p>
+                    </div>
+
+                    <div class="-mx-5 -mb-5 mt-1 flex items-center justify-end gap-2 border-t border-mercury bg-skull/40 px-5 py-3">
+                        <button type="button" data-proof-close class="inline-flex h-10 items-center justify-center gap-1.5 rounded-lg border border-mercury bg-white px-4 text-[13px] font-semibold text-foreground transition hover:bg-skull">Batal</button>
+                        <button type="submit" data-proof-submit class="inline-flex h-10 items-center justify-center gap-1.5 rounded-lg bg-primary px-4 text-[13px] font-bold text-white shadow-sm transition hover:bg-primary-light disabled:cursor-not-allowed disabled:opacity-60">
+                            <i class="ri-upload-2-line"></i> Unggah
                         </button>
                     </div>
                 </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ Route::middleware('auth')->prefix('admin')->name('admin.')->group(function () {
     Route::post('/orders/{order}/status', [AdminController::class, 'updateStatus'])->name('orders.status');
     Route::post('/orders/{order}/shipping', [AdminController::class, 'updateShipping'])->name('orders.shipping');
     Route::post('/orders/{order}/pickup', [AdminController::class, 'updatePickup'])->name('orders.pickup');
+    Route::post('/orders/{order}/payment-proof', [AdminController::class, 'uploadPaymentProof'])->name('orders.payment-proof');
     Route::post('/orders/{order}/dp-proof', [AdminController::class, 'uploadDpProof'])->name('orders.dp-proof');
     Route::post('/orders/{order}/settlement-verify', [AdminController::class, 'verifySettlement'])->name('orders.settlement-verify');
     Route::post('/orders/{order}/sync-payment', [AdminController::class, 'syncPayment'])->name('orders.sync-payment');


### PR DESCRIPTION
## Summary

Adds admin-side management of payment transfer proofs. Previously transfer proofs could only be uploaded by customers; admins could view them but had no way to add a missing proof or replace an incorrect one. This PR introduces upload/replace actions directly in the order detail panel.

DP orders carry two distinct proof slots — the initial DP transfer and the settlement proof — so each slot now gets its own independent add/replace action.

## Changes

- **New endpoint** `POST /admin/orders/{order}/payment-proof` (`AdminController::uploadPaymentProof`) handling both `payment` and `settlement` proof types. Validates the file (jpg/png/webp/pdf, max 5MB), deletes the previous file when replacing, and stores it under `proofs/` or `proofs/settlements/` accordingly. Settlement uploads are restricted to DP orders.
- **Redesigned proof section** in the order detail modal: replaced the cluttered chip row with clean per-slot rows. Each row shows the proof label, upload status (uploaded date or "Belum ada bukti"), and contextual actions — "Lihat" (view), "Tambah" (add), and "Ganti" (replace).
- **Reusable upload modal** with client-side validation (required file, max 5MB). On success it refreshes the stats cards, reloads the orders table, and re-renders the open detail view.

## Behavior notes

- Uploading a proof only manages the file; it does **not** change the order status or auto-verify. Settlement verification remains a separate explicit action ("Verifikasi Pelunasan"), so admins can correct/replace photos at any time without unintentionally altering payment status.
- Bayar Lunas (full payment) orders show a single proof slot; DP orders show two.

## Testing

- `php -l` passes for `AdminController.php`
- `node --check` passes for `admin-dashboard.js`
- `npm run build` succeeds
- Route registered as `admin.orders.payment-proof`